### PR TITLE
Update Main.cs

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -310,7 +310,7 @@ namespace winsw
             {
                 if (mo["ExecutablePath"].Equals(descriptor.BasePath + ".exe"))
                 {
-                    WriteEvent("Not killing service wrapper request, PID: " + pid);
+                    WriteEvent("Not killing service wrapper request, PID: " + mo["ProcessID"]);
                     continue;
                 }
                 StopProcessAndChildren(Convert.ToInt32(mo["ProcessID"]));


### PR DESCRIPTION
When stopping the children processes of a parent process, do not stop a child if it is executing the service wrapper itself (for instance, because the parent spawned a process to execute "[wrapper.exe] restart"). This is a resolution for [JENKINS-22685].

Also, updated logging of SIGINT to properly reflect the PID being stopped. Previously, it was always printing the main parent's PID even when SIGINTing a child PID.
