### PR TITLE
[FIXED JENKINS-10547] Don't fail fatally when unable to log event

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -138,7 +138,14 @@ namespace winsw
             }
             else
             {
-                EventLog.WriteEntry(message);
+                try
+                {
+                    EventLog.WriteEntry(message);
+                }
+                catch (Exception e)
+                {
+                    WriteEvent("Failed to log event in Windows Event Log: " + message + "; Reason: ", e);
+                }
             }
         }
 
@@ -150,7 +157,14 @@ namespace winsw
             }
             else
             {
-                EventLog.WriteEntry(message, type);
+                try
+                {
+                    EventLog.WriteEntry(message, type);
+                }
+                catch (Exception e)
+                {
+                    WriteEvent("Failed to log event in Windows Event Log. Reason: ", e);
+                }
             }
         }
 


### PR DESCRIPTION
Instead, handle the exception and write it to the `wrapper.log` so users have a way to learn what's going on.
