### PR TITLE
Use total seconds of TimeSpan for reset period

### DIFF
--- a/Advapi32.cs
+++ b/Advapi32.cs
@@ -49,7 +49,7 @@ namespace winsw
         public void ChangeConfig(TimeSpan failureResetPeriod, List<SC_ACTION> actions)
         {
             SERVICE_FAILURE_ACTIONS sfa = new SERVICE_FAILURE_ACTIONS();
-            sfa.dwResetPeriod = failureResetPeriod.Seconds;
+            sfa.dwResetPeriod = (int)failureResetPeriod.TotalSeconds;
             sfa.lpRebootMsg = ""; // delete message
             sfa.lpCommand = "";   // delete the command to run
             


### PR DESCRIPTION
This fixes a bug where setting `resetfailure` to something like "1 day" resulted in 0 seconds being passed to dwResetPeriod. This was because the `Seconds` property only contains the seconds component of the `TimeSpan`, while `TotalSeconds` contains the total seconds in the entire `TimeSpan`.
