### PR TITLE
README: Escape allowservicelogon tags

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -277,7 +277,7 @@ It is possible to specify the useraccount (and password) that the service will r
        <allowservicelogon>true</allowservicelogon>
     </serviceaccount>
 
-The <allowservicelogon> is optional.  If set to true, will automatically set the "Allow Log On As A Service" right to the listed account.
+The `<allowservicelogon>` is optional.  If set to true, will automatically set the "Allow Log On As A Service" right to the listed account.
 
 ### Working directory
 Some services need to run with a working directory specified. To do this, specify a `<workingdirectory>` element like this:


### PR DESCRIPTION
'allowservicelogon' in the note wasn't displaying due to the xml tags.