### PR TITLE
Adds Puppet Module Page and Link on ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*winsw: Windows service wrapper in less restrictive license
+winsw: Windows service wrapper in less restrictive license
 =========================
 
 WinSW is an executable binary, which can be used to wrap and manage a custom process as a Windows service.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Your renamed `winsw.exe` binary also accepts the following commands:
  * [Self-restarting services](doc/selfRestartingService.md)
  * [Deferred File Operations](doc/deferredFileOperations.md)
 * Configuration Management:
- * Puppet Forge Module(doc/puppetWinSQ.md)
+ * [Puppet Forge Module](doc/puppetWinSQ.md)
 
 ### Release lines
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-winsw: Windows service wrapper in less restrictive license
+*winsw: Windows service wrapper in less restrictive license
 =========================
 
 WinSW is an executable binary, which can be used to wrap and manage a custom process as a Windows service.
@@ -40,6 +40,8 @@ Your renamed `winsw.exe` binary also accepts the following commands:
 * Use-cases:
  * [Self-restarting services](doc/selfRestartingService.md)
  * [Deferred File Operations](doc/deferredFileOperations.md)
+* Configuration Management:
+ * Puppet Forge Module(doc/puppetWinSQ.md)
 
 ### Release lines
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Your renamed `winsw.exe` binary also accepts the following commands:
  * [Self-restarting services](doc/selfRestartingService.md)
  * [Deferred File Operations](doc/deferredFileOperations.md)
 * Configuration Management:
- * [Puppet Forge Module](doc/puppetWinSQ.md)
+ * [Puppet Forge Module](doc/puppetWinSW.md)
 
 ### Release lines
 

--- a/doc/puppetWinSW.md
+++ b/doc/puppetWinSW.md
@@ -1,0 +1,1 @@
+## Puppet Module Now Available!

--- a/doc/puppetWinSW.md
+++ b/doc/puppetWinSW.md
@@ -1,1 +1,9 @@
 ## Puppet Module Now Available!
+
+Happy to announce there is now a module in the Puppet Forge for anyone 
+who is utilizing Puppet CM. ( as of 11/29/2016 ) 
+
+Please checkout the [Puppet Forge Page](http://forge.puppet.com/kenmaglio/winsw) 
+for more information about specifics of this module. 
+
+[Git Hub Project Page](http://github.com/kenmaglio/winsw)


### PR DESCRIPTION
Adding a page to at least link to the puppet forge page and GitHub for now. 

Can always make the documentation better, however I didn't want to duplicate too much of what's already on the Puppet Forge documentation.