### PR TITLE
Improve handling of initialization errors

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -513,11 +513,13 @@ namespace winsw
             }
             catch (WmiException e)
             {
+                Log.Fatal("WMI Operation failure: " + e.ErrorCode, e);
                 Console.Error.WriteLine(e);
                 return (int)e.ErrorCode;
             }
             catch (Exception e)
             {
+                Log.Fatal("Unhandled exception", e);
                 Console.Error.WriteLine(e);
                 return -1;
             }
@@ -528,17 +530,29 @@ namespace winsw
             throw new WmiException(ReturnValue.NoSuchService);
         }
 
+
         // ReSharper disable once InconsistentNaming
+        /// <summary>
+        /// Runs the wrapper.
+        /// </summary>
+        /// <param name="_args">Arguments. If empty, WinSW will behave in the service mode. Otherwise - CLI mode</param>
+        /// <param name="descriptor">Service descriptor. If null, it will be initialized within the method. 
+        ///                          In such case configs will be loaded from the XML Configuration File.</param>
+        /// <exception cref="Exception">Any unhandled exception</exception>
         public static void Run(string[] _args, ServiceDescriptor descriptor = null)
         {
             bool isCLIMode = _args.Length > 0;
+            
+            
+            // If descriptor is not specified, initialize the new one (and load configs from there)
             var d = descriptor ?? new ServiceDescriptor();
-
-            // Configure the wrapper-internal logging
-            // STDIN and STDOUT of the child process will be handled independently
+                
+            // Configure the wrapper-internal logging.
+            // STDIN and STDOUT of the child process will be handled independently.
             InitLoggers(d, isCLIMode);
 
-            if (isCLIMode) // CLI mode
+            
+            if (isCLIMode) // CLI mode, in-service mode otherwise
             {               
                 Log.Debug("Starting ServiceWrapper in CLI mode");
 

--- a/src/Core/WinSWCore/Extensions/WinSWExtensionManager.cs
+++ b/src/Core/WinSWCore/Extensions/WinSWExtensionManager.cs
@@ -86,6 +86,11 @@ namespace winsw.Extensions
         //TODO: Implement loading of external extensions. Current version supports internal hack
         #region Extension load management
 
+        /// <summary>
+        /// Loads extensions according to the configuration file.
+        /// </summary>
+        /// <param name="logger">Logger</param>
+        /// <exception cref="Exception">Loading failure</exception>
         public void LoadExtensions(IEventWriter logger)
         {
             var extensionIds = ServiceDescriptor.ExtensionIds;
@@ -100,7 +105,7 @@ namespace winsw.Extensions
         /// </summary>
         /// <param name="id">Extension ID</param>
         /// <param name="logger">Logger</param>
-        /// <exception cref="ExtensionException">Loading failure</exception>
+        /// <exception cref="Exception">Loading failure</exception>
         private void LoadExtension(string id, IEventWriter logger)
         {
             if (Extensions.ContainsKey(id))
@@ -120,8 +125,15 @@ namespace winsw.Extensions
             {
                 IWinSWExtension extension = CreateExtensionInstance(descriptor.Id, descriptor.ClassName);
                 extension.Descriptor = descriptor;
-                //TODO: Handle exceptions
-                extension.Configure(ServiceDescriptor, configNode, logger);
+                try
+                {
+                    extension.Configure(ServiceDescriptor, configNode, logger);
+                }
+                catch (Exception ex)
+                { // Consider any unexpected exception as fatal
+                    Log.Fatal("Failed to configure the extension " + id, ex);
+                    throw ex;
+                }
                 Extensions.Add(id, extension);
                 logger.LogEvent("Extension loaded: "+id, EventLogEntryType.Information);
             }


### PR DESCRIPTION
Due to the lack of logging on the top level, particular issues in WinSW cause failure without any message in system and event logs. This PR improves logging a bit.

- [x] - Extension configuration failure should be logged as Fatal
- [x] - Any failures on the top-level should be captured and also logged. Depending on the Log appender status, the errors will be either printed to the wrapper log or Stderr

Fixes #134 