### PR TITLE
Provide the new .NET4-compatible executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Your renamed `winsw.exe` binary also accepts the following commands:
 * `restart` to restart the service. If the service is not currently running, this command acts like `start`.
 * `status` to check the current status of the service. This command prints one line to the console. `NonExistent` to indicate the service is not currently installed, `Started` to indicate the service is currently running, and `Stopped` to indicate that the service is installed but not currently running.
 
+### Supported .NET versions
+
+WinSW `1.x` Executable is being built with a .NET Framework `2.0` target, and by defaut it will work only for .NET Framework versions below `3.5`.
+On the other hand, the code is known to be compatible with .NET Framework `4.0` and above.
+It is possible to declare the support of this framework via the `exe.config` file.
+See the [Installation Guide](doc/installation.md) for more details.
+
+WinSW `2.x` offers two executables, which declare .NET Frameworks `2.0` and `4.0` as targets.
+Naming and download sources for these binaries are currently in flux.
+
 ### Documentation
 
 * [Installation Guide](doc/installation.md) - Describes the installation process for different systems and .NET versions
@@ -57,6 +67,7 @@ Major changes since 1.x:
 * Rework of the project structure
 * Better logging
 * [Internal extension engine](doc/extensions/extensions.md), which allows extending the WinSW behavior
+* Executable package targeting the .NET Framework 4.0
 
 #### WinSW 1.x
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,8 @@ test_script:
 artifacts:
   - path: 'src/Core/ServiceWrapper/bin/Release/winsw.exe'
     name: WinSW
+  - path: 'src/Core/ServiceWrapper_dotNET4/bin/Release/winsw.exe'
+    name: WinSW_dotNET4
 
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,10 +31,10 @@ test_script:
 - ps: nunit-console 'C:/projects/winsw/src/Test/winswTests/bin/Release/winswTests.dll' 'C:/projects/winsw/src/Test/winswTests/bin/Release/SharedDirectoryMapper.dll' 'C:/projects/winsw/src/Test/winswTests/bin/Release/RunawayProcessKiller.dll'
 
 artifacts:
-  - path: 'src/Core/ServiceWrapper/bin/Release/winsw.exe'
-    name: WinSW
-  - path: 'src/Core/ServiceWrapper_dotNET4/bin/Release/winsw.exe'
-    name: WinSW_dotNET4
+  - path: 'src/Core/ServiceWrapper/bin/Release/WinSW.NET2.exe'
+    name: WinSW.NET2.exe
+  - path: 'src/Core/ServiceWrapper_dotNET4/bin/Release/WinSW.NET4.exe'
+    name: WinSW.NET4.exe
 
 
 

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -137,7 +137,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <!-- Merge plugins and other DLLs into winsw.exe -->
+  <!-- Merge plugins and other DLLs into the executable -->
   <UsingTask TaskName="MSBuild.Community.Tasks.ILMerge" AssemblyFile="$(SolutionDir)\packages\MSBuildTasks.1.4.0.88\tools\MSBuild.Community.Tasks.dll" />
   <Target Name="AfterBuild">
     <ItemGroup>
@@ -148,7 +148,7 @@
       <MergeAsm Include="$(OutputPath)log4net.dll" />
     </ItemGroup>
     <PropertyGroup>
-      <MergedAssembly>$(ProjectDir)$(OutDir)winsw.exe</MergedAssembly>
+      <MergedAssembly>$(ProjectDir)$(OutDir)WinSW.NET2.exe</MergedAssembly>
       <CertificatePfxFile>$(AssemblyOriginatorKeyFile)</CertificatePfxFile>
     </PropertyGroup>
     <!-- Locate SN.EXE in Windows SDK, use the first found one-->

--- a/src/Core/ServiceWrapper_dotNET4/Main.cs
+++ b/src/Core/ServiceWrapper_dotNET4/Main.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace winsw.dotNET4
+{
+    /// <summary>
+    /// Just a wrapper class, which redirects the Main entry point to the WinSW main method.
+    /// </summary>
+    public class dotNET4Support
+    {
+        public static int Main(string[] args)
+        {
+            return winsw.WrapperService.Main(args);
+        }
+    }
+}

--- a/src/Core/ServiceWrapper_dotNET4/Properties/AssemblyInfo.cs
+++ b/src/Core/ServiceWrapper_dotNET4/Properties/AssemblyInfo.cs
@@ -1,0 +1,32 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Windows Service Wrapper for .NET4")]
+[assembly: AssemblyDescription("Allows arbitrary process to run as a Windows service by wrapping it")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("CloudBees, Inc.")]
+[assembly: AssemblyProduct("Windows Service Wrapper")]
+[assembly: AssemblyCopyright("Copyright 2008-2016 Oleg Nenashev, CloudBees, Inc. and other contributors")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("59ce18df-cacb-4360-bb80-798bd6459ca3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyFileVersion("2.0.*")]

--- a/src/Core/ServiceWrapper_dotNET4/packages.config
+++ b/src/Core/ServiceWrapper_dotNET4/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ILMerge" version="2.14.1208" targetFramework="net20" />
+  <package id="log4net" version="2.0.3" targetFramework="net20" requireReinstallation="True" />
+  <package id="MSBuildTasks" version="1.4.0.88" targetFramework="net20" />
+</packages>

--- a/src/Core/ServiceWrapper_dotNET4/winsw_dotNET4.csproj
+++ b/src/Core/ServiceWrapper_dotNET4/winsw_dotNET4.csproj
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{419AEEA7-E7DE-4A76-B001-76DB5F98C838}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>winsw.dotNET4</RootNamespace>
+    <AssemblyName>WindowsService_dotNET4</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <StartupObject>
+    </StartupObject>
+    <SignManifests>false</SignManifests>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)..\winsw_key.snk</AssemblyOriginatorKeyFile>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>
+    </DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net">
+      <HintPath>..\..\packages\log4net.2.0.3\lib\net20-full\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="manifest.xml" />
+    <Content Include="winsw.xml">
+      <SubType>Designer</SubType>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="$(AssemblyOriginatorKeyFile)" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\RunawayProcessKiller\RunawayProcessKiller.csproj">
+      <Project>{57284b7a-82a4-407a-b706-ebea6bf8ea13}</Project>
+      <Name>RunawayProcessKiller</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Plugins\SharedDirectoryMapper\SharedDirectoryMapper.csproj">
+      <Project>{ca5c71db-c5a8-4c27-bf83-8e6daed9d6b5}</Project>
+      <Name>SharedDirectoryMapper</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ServiceWrapper\winsw.csproj">
+      <Project>{0de77f55-ade5-43c1-999a-0bc81153b039}</Project>
+      <Name>winsw</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\WinSWCore\WinSWCore.csproj">
+      <Project>{9d0c63e2-b6ff-4a85-bd36-b3e5d7f27d06}</Project>
+      <Name>WinSWCore</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- Merge plugins and other DLLs into winsw.exe -->
+  <UsingTask TaskName="MSBuild.Community.Tasks.ILMerge" AssemblyFile="$(SolutionDir)\packages\MSBuildTasks.1.4.0.88\tools\MSBuild.Community.Tasks.dll" />
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <MergeAsm Include="$(OutputPath)$(TargetFileName)" />
+      <MergeAsm Include="$(OutputPath)WindowsService.exe" />
+	  <MergeAsm Include="$(OutputPath)WinSWCore.dll" />
+      <MergeAsm Include="$(OutputPath)SharedDirectoryMapper.dll" />
+      <MergeAsm Include="$(OutputPath)RunawayProcessKiller.dll" />
+      <MergeAsm Include="$(OutputPath)log4net.dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <MergedAssembly>$(ProjectDir)$(OutDir)winsw.exe</MergedAssembly>
+      <CertificatePfxFile>$(AssemblyOriginatorKeyFile)</CertificatePfxFile>
+    </PropertyGroup>
+    <!-- Locate SN.EXE in Windows SDK, use the first found one-->
+    <PropertyGroup>
+      <SnPathTmpFile>$(OutputPath)sn-path.txt</SnPathTmpFile>
+    </PropertyGroup>
+    <GetFrameworkSdkPath>
+      <Output TaskParameter="Path" PropertyName="WindowsSdkPath" />
+    </GetFrameworkSdkPath>
+    <Message Text="Using SDK from $(WindowsSdkPath)" Importance="high" />
+    <Exec Command="WHERE /r &quot;$(WindowsSdkPath.TrimEnd('\\'))&quot; sn &gt; $(SnPathTmpFile)" />
+    <ReadLinesFromFile File="$(SnPathTmpFile)">
+      <Output TaskParameter="Lines" PropertyName="SNPath" />
+    </ReadLinesFromFile>
+    <Delete Files="$(SnPathTmpFile)" />
+    <PropertyGroup>
+      <SNPath>$([System.Text.RegularExpressions.Regex]::Replace('$(SNPath)', ';.*', ''))</SNPath>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SNPath)')" Text="Cannot find SN.EXE utility in $(WindowsSdkPath)" />
+    <Message Text="Using SN.EXE utility from $(SNPath)" Importance="high" />
+    <!-- Merge and re-sign assemblies -->
+    <PropertyGroup>
+      <ILMergePath>$(SolutionDir)packages\ilmerge.2.14.1208\tools</ILMergePath>
+      <CertificateTmpPubFile>$(OutputPath)winsw_cert.pub</CertificateTmpPubFile>
+    </PropertyGroup>
+    <Message Text="Extracting public key from $(AssemblyOriginatorKeyFile)" />
+    <Exec Command="&quot;$(SNPath)&quot; -p &quot;$(AssemblyOriginatorKeyFile)&quot; &quot;$(CertificateTmpPubFile)&quot;" />
+    <Message Text="ILMerge @(MergeAsm) -&gt; $(MergedAssembly)" Importance="high" />
+    <ILMerge ToolPath="$(ILMergePath)" InputAssemblies="@(MergeAsm)" OutputFile="$(MergedAssembly)" TargetKind="SameAsPrimaryAssembly" KeyFile="$(CertificateTmpPubFile)" DelaySign="true" />
+    <Exec Command="&quot;$(SNPath)&quot; -R &quot;$(MergedAssembly)&quot; &quot;$(AssemblyOriginatorKeyFile)&quot;" />
+  </Target>
+</Project>

--- a/src/Core/ServiceWrapper_dotNET4/winsw_dotNET4.csproj
+++ b/src/Core/ServiceWrapper_dotNET4/winsw_dotNET4.csproj
@@ -135,7 +135,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <!-- Merge plugins and other DLLs into winsw.exe -->
+  <!-- Merge plugins and other DLLs into the executable -->
   <UsingTask TaskName="MSBuild.Community.Tasks.ILMerge" AssemblyFile="$(SolutionDir)\packages\MSBuildTasks.1.4.0.88\tools\MSBuild.Community.Tasks.dll" />
   <Target Name="AfterBuild">
     <ItemGroup>
@@ -147,7 +147,7 @@
       <MergeAsm Include="$(OutputPath)log4net.dll" />
     </ItemGroup>
     <PropertyGroup>
-      <MergedAssembly>$(ProjectDir)$(OutDir)winsw.exe</MergedAssembly>
+      <MergedAssembly>$(ProjectDir)$(OutDir)WinSW.NET4.exe</MergedAssembly>
       <CertificatePfxFile>$(AssemblyOriginatorKeyFile)</CertificatePfxFile>
     </PropertyGroup>
     <!-- Locate SN.EXE in Windows SDK, use the first found one-->

--- a/src/Core/ServiceWrapper_dotNET4/winsw_dotNET4.csproj
+++ b/src/Core/ServiceWrapper_dotNET4/winsw_dotNET4.csproj
@@ -85,7 +85,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -142,7 +141,7 @@
     <ItemGroup>
       <MergeAsm Include="$(OutputPath)$(TargetFileName)" />
       <MergeAsm Include="$(OutputPath)WindowsService.exe" />
-	  <MergeAsm Include="$(OutputPath)WinSWCore.dll" />
+      <MergeAsm Include="$(OutputPath)WinSWCore.dll" />
       <MergeAsm Include="$(OutputPath)SharedDirectoryMapper.dll" />
       <MergeAsm Include="$(OutputPath)RunawayProcessKiller.dll" />
       <MergeAsm Include="$(OutputPath)log4net.dll" />

--- a/src/winsw.sln
+++ b/src/winsw.sln
@@ -31,6 +31,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{D88064
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RunawayProcessKiller", "Plugins\RunawayProcessKiller\RunawayProcessKiller.csproj", "{57284B7A-82A4-407A-B706-EBEA6BF8EA13}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "winsw_dotNET4", "Core\ServiceWrapper_dotNET4\winsw_dotNET4.csproj", "{419AEEA7-E7DE-4A76-B001-76DB5F98C838}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -99,6 +101,16 @@ Global
 		{57284B7A-82A4-407A-B706-EBEA6BF8EA13}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{57284B7A-82A4-407A-B706-EBEA6BF8EA13}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{57284B7A-82A4-407A-B706-EBEA6BF8EA13}.Release|Win32.ActiveCfg = Release|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Release|Any CPU.Build.0 = Release|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838}.Release|Win32.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -109,5 +121,6 @@ Global
 		{CA5C71DB-C5A8-4C27-BF83-8E6DAED9D6B5} = {BC4AD891-E87E-4F30-867C-FD8084A29E5D}
 		{9D0C63E2-B6FF-4A85-BD36-B3E5D7F27D06} = {5297623A-1A95-4F89-9AAE-DA634081EC86}
 		{57284B7A-82A4-407A-B706-EBEA6BF8EA13} = {BC4AD891-E87E-4F30-867C-FD8084A29E5D}
+		{419AEEA7-E7DE-4A76-B001-76DB5F98C838} = {5297623A-1A95-4F89-9AAE-DA634081EC86}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
According to the requests, it is not always convenient to declare the `.NET Framework 4` support in `exe.config`. Such approach also does not guarantee that the executable is really operational in this framework.

This PR adds a new project, which generates a binary targeting `.NET Framework 4.0`.

- [x] Add new project with .NET4-compatible executor
- [x] Modify AppVeyor settings to publish this artifact
- [x] Update README to mention the supported versions

Addresses #103, #112, ant #102

@reviewbybees