### PR TITLE
Setup proper assembly versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ before_build:
 
 assembly_info:
   patch: true
-  file: "**\AssemblyInfo.*"
+  file: "**\\AssemblyInfo.*"
   assembly_version:  $(appveyor_build_version)
   assembly_file_version:  $(appveyor_build_version)
   assembly_informational_version: '$(appveyor_build_version)-rc'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ before_build:
 
 assembly_info:
   patch: true
-  file: "**/AssemblyInfo.*"
+  file: "**\AssemblyInfo.*"
   assembly_version:  $(appveyor_build_version)
   assembly_file_version:  $(appveyor_build_version)
   assembly_informational_version: '$(appveyor_build_version)-rc'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 
-version: 2.0.0.{build}
+version: 2.0.{build}
 
 # Do not build on tags (GitHub and BitBucket)
 skip_tags: true
@@ -22,6 +22,13 @@ before_build:
   # Generates a temporary SNK. Not for real signing
   - cmd: "\"C:/Program Files/Microsoft SDKs/Windows/v7.1/Bin/sn.exe\" -k winsw_key.snk"
 
+assembly_info:
+  patch: true
+  file: "**/AssemblyInfo.*"
+  assembly_version:  $(appveyor_build_version)
+  assembly_file_version:  $(appveyor_build_version)
+  assembly_informational_version: '$(appveyor_build_version)-rc'
+  
 build:
   parallel: true 
   project:  src\winsw.sln 

--- a/src/Core/ServiceWrapper/Properties/AssemblyInfo.cs
+++ b/src/Core/ServiceWrapper/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.19.1.0")]
-[assembly: AssemblyFileVersion("1.19.1.0")]
+[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyFileVersion("2.0.*")]

--- a/src/Core/ServiceWrapper/pom.xml
+++ b/src/Core/ServiceWrapper/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.sun.winsw</groupId>
   <artifactId>winsw</artifactId>
   <packaging>pom</packaging>
-  <version>1.19.2-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <name>Windows service wrapper</name>
     
   <distributionManagement>

--- a/src/Core/WinSWCore/Properties/AssemblyInfo.cs
+++ b/src/Core/WinSWCore/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyFileVersion("2.0.*")]

--- a/src/Plugins/RunawayProcessKiller/Properties/AssemblyInfo.cs
+++ b/src/Plugins/RunawayProcessKiller/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyFileVersion("2.0.*")]

--- a/src/Plugins/SharedDirectoryMapper/Properties/AssemblyInfo.cs
+++ b/src/Plugins/SharedDirectoryMapper/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyFileVersion("2.0.*")]

--- a/src/Test/winswTests/Properties/AssemblyInfo.cs
+++ b/src/Test/winswTests/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyFileVersion("2.0.*")]


### PR DESCRIPTION
- [x] All versions point to `2.0.*`
- [x] AppVeyor now patches assembly versions to reflect the build number