### PR TITLE
Handover Version control to AppVeyor jobs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,3 @@
-
-version: '2.0-SNAPSHOT-build{build}'
-
 # Do not build on tags (GitHub and BitBucket)
 skip_tags: true
 


### PR DESCRIPTION
In order to maintain Release and Snapshot versions on AppVeyor, I had to create two separate jobs on it. These jobs utilise the same config, but actually they only specify different version formats.

* Release job: `2.0.{build}`
* Snapshot & PR builder: 2.0-SNAPSHOT-build{build}

Maybe it's not the best practice