### PR TITLE
AppVeyor Builder generalization

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ build:
 
 test_script:
 # Runner for NUnit2
-- ps: nunit-console 'C:/projects/winsw/src/Test/winswTests/bin/Release/winswTests.dll' 'C:/projects/winsw/src/Test/winswTests/bin/Release/SharedDirectoryMapper.dll' 'C:/projects/winsw/src/Test/winswTests/bin/Release/RunawayProcessKiller.dll'
+- ps: nunit-console 'src/Test/winswTests/bin/Release/winswTests.dll' 'src/Test/winswTests/bin/Release/SharedDirectoryMapper.dll' 'src/Test/winswTests/bin/Release/RunawayProcessKiller.dll'
 
 artifacts:
   - path: 'src/Core/ServiceWrapper/bin/Release/WinSW.NET2.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
-# Do not build on tags (GitHub and BitBucket)
+# Do not build tags and feature branches
 skip_tags: true
+skip_branch_with_pr: true
 
 # Project configuration
 image: Visual Studio 2013


### PR DESCRIPTION
- [x] Do not build feature branches. Master is the only target branch with CI support now
- [x] Use relative paths to make the [release builder](https://ci.appveyor.com/project/oleg-nenashev/winsw-g2fwp) running