### PR TITLE
Maven POM update towards 2.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,12 @@
   <artifactId>winsw</artifactId>
   <packaging>pom</packaging>
   <version>2.0-SNAPSHOT</version>
-  <name>Windows service wrapper</name>
+  <name>Windows Service Wrapper (WinSW)</name>
     
+  <properties>
+    <winsw.version>2.0.3</winsw.version>
+  </properties>  
+  
   <distributionManagement>
     <repository>
       <id>maven.jenkins-ci.org</id>
@@ -19,17 +23,17 @@
     <url>https://github.com/kohsuke/winsw</url>
     <tag>HEAD</tag>
   </scm>
-
+  
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
       </plugin>
-      <!-- fake out maven and install the binary artifact -->
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
         <artifactId>maven-antrun-extended-plugin</artifactId>
+        <version>1.43</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -38,7 +42,10 @@
             </goals>
             <configuration>
               <tasks>
-                <attachArtifact file="bin/Release/winsw.exe" type="exe" classifier="bin" />
+                <mkdir dir="${project.build.directory}/bin/"/>
+                <get src="https://github.com/kohsuke/winsw/releases/download/winsw-draft-v${winsw.version}/WinSW.NET2.exe" 
+                     dest="${project.build.directory}/bin/winsw.exe"/>
+                <attachArtifact file="${project.build.directory}/bin/bin/winsw.exe" type="exe" classifier="bin" />
               </tasks>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,30 @@
   <packaging>pom</packaging>
   <version>2.0-SNAPSHOT</version>
   <name>Windows Service Wrapper (WinSW)</name>
-    
+  <url>https://github.com/kohsuke/winsw/</url>
+   
   <properties>
     <winsw.version>2.0.3</winsw.version>
-  </properties>  
+  </properties>
+  
+  <licenses>
+    <license>
+      <name>The MIT license</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>  
+  
+  <developers>
+    <developer>
+      <id>oleg_nenashev</id>
+      <name>Oleg Nenashev</name>
+      <roles>
+        <role>Maintainer</role>
+      </roles>
+      <url>https://github.com/oleg-nenashev/</url>
+    </developer>
+  </developers>
   
   <distributionManagement>
     <repository>
@@ -16,6 +36,11 @@
       <url>https://repo.jenkins-ci.org/releases/</url>
     </repository>
   </distributionManagement>
+  
+  <ciManagement>
+    <system>AppVeyor</system>
+    <url>https://ci.appveyor.com/project/oleg-nenashev/winsw</url>
+  </ciManagement>
 
   <scm>
     <connection>scm:git:ssh://github.com/kohsuke/winsw.git</connection>
@@ -53,12 +78,4 @@
       </plugin>
     </plugins>
   </build>
-  
-  <licenses>
-    <license>
-      <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,9 @@
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
+        <configuration>
+          <releaseProfiles>release-verify-winsw-version</releaseProfiles>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
@@ -78,4 +81,49 @@
       </plugin>
     </plugins>
   </build>
+  
+  <!-- Ensures that the version of the released WinSW package equals to WinSW-->
+  <profiles>
+    <profile>
+      <id>release-verify-winsw-version</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
+            <artifactId>maven-antrun-extended-plugin</artifactId>
+            <version>1.43</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                             classpathref="maven.plugin.classpath" />
+                    <if>
+                      <not>
+                        <equals arg1="${project.version}" arg2="${winsw.version}"/>
+                      </not>
+                      <then>
+                        <fail message="Project version ${project.version} is different from the WinSW version ${winsw.version}."/>
+                      </then>
+                    </if>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>ant-contrib</groupId>
+                <artifactId>ant-contrib</artifactId>
+                <version>20020829</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>               
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Add support of Maven releases for the 2.0 release

- [x] - Use GitHub Releases as a source of the binary file (yes, you do not need Windows to release to Maven anymore)
- [x] - Enhance the POM.xml description
- [x] - Add verification of POM/WinSW consistency during the release

Fixes #80 