### PR TITLE
Do not propagate exceptions from Process.Kill() if the process actually exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ New versions with fixes may be released on-demand.
 ### Build Environment
 
 * IDE: [Visual Studio Community 2013](http://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx) (free for open-source projects)
-* `winsw-key.snk` should be available in the project's root in order to build the executable
+* `winsw_key.snk` should be available in the project's root in order to build the executable
  * You can generate the certificate in "Project Settings/Signing"
  * The certificate is in <code>.gitignore</code> list. Please do not add it to the repository

--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -66,9 +66,15 @@ namespace winsw.Util
                     Logger.Warn("SIGINT to " + pid + " failed - Killing as fallback");
                     proc.Kill();
                 }
-                catch (ArgumentException)
+                catch (Exception ex)
                 {
+                    if (!proc.HasExited)
+                    {
+                        throw;
+                    }
+
                     // Process already exited.
+                    Logger.Warn("Ignoring exception from killing process because it has exited", ex);
                 }
             }
 


### PR DESCRIPTION
Sometimes we get an InvalidOperationException when we kill a process that is already dead and other times we get a Win32Exception. Let's ignore all exceptions from killing a process if it has exited.

Additionally, ArgumentException is the wrong exception to catch. I have never seen Process.Kill() throw that. It seems to be a bad copy and paste from line 50.