### PR TITLE
Issue #59 - Prevent failure when Child processes cannot be retrieved due to the system shutdown

### DIFF
--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -90,23 +90,32 @@ namespace winsw.Util
         /// <param name="stopParentProcessFirst">If enabled, the perent process will be terminated before its children on all levels</param>
         public static void StopProcessAndChildren(int pid, TimeSpan stopTimeout, bool stopParentProcessFirst)
         {
-            var childPids = GetChildPids(pid);
-
-            if (stopParentProcessFirst)
+            List<int> childPids = null;
+            try
             {
-                StopProcess(pid, stopTimeout);
+                childPids = GetChildPids(pid);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn("Failed to locate children of the process with PID=" + pid + ". Child processes won't be terminated", ex);
+            }
+
+            if (!stopParentProcessFirst && childPids != null)
+            {  
                 foreach (var childPid in childPids)
                 {
                     StopProcessAndChildren(childPid, stopTimeout, stopParentProcessFirst);
                 }
             }
-            else
+
+            StopProcess(pid, stopTimeout);
+
+            if (stopParentProcessFirst && childPids != null)
             {
                 foreach (var childPid in childPids)
                 {
                     StopProcessAndChildren(childPid, stopTimeout, stopParentProcessFirst);
                 }
-                StopProcess(pid, stopTimeout);
             }
         }
 


### PR DESCRIPTION
Addresses #59 and [JENKINS-22692](https://issues.jenkins-ci.org/browse/JENKINS-22692)

This is a bit hackish way, which still terminates the spawned process even in the case of the ongoing system shutdown. In Jenkins project it should help with enforced termination of Windows agents, which somehow leaves hanging connections on the master side. Maybe this issue has been already solved in other way on the remoting side, but there is no confirmations from users....

@reviewbybees