### PR TITLE
Fixes #54. Do not dump WinSW environment variables to the Event log

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -210,10 +210,13 @@ namespace winsw
         protected override void OnStart(string[] _)
         {
             _envs = _descriptor.EnvironmentVariables;
+            // TODO: Disabled according to security concerns in https://github.com/kohsuke/winsw/issues/54
+            // Could be restored, but unlikely it's required in event logs at all
+            /**
             foreach (string key in _envs.Keys)
             {
                 LogEvent("envar " + key + '=' + _envs[key]);
-            }
+            }*/
 
             HandleFileCopies();
 


### PR DESCRIPTION
See #54. @kenny-evitt was concerned about dumping of environment variables from the XML config file to the Event Log since they may contain secrets. I do not see much sense in writing such information to the event log, so I've decided to disable such logging at all in WinSW 2.0.

CC @daniel-beck as a Jenkins security officer.

@reviewbybees