### PR TITLE
Fixes #95 - Service not sending SIGINT properly to java

### DIFF
--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -172,7 +172,7 @@
     <Message Text="Extracting public key from $(AssemblyOriginatorKeyFile)" />
     <Exec Command="&quot;$(SNPath)&quot; -p &quot;$(AssemblyOriginatorKeyFile)&quot; &quot;$(CertificateTmpPubFile)&quot;" />
     <Message Text="ILMerge @(MergeAsm) -&gt; $(MergedAssembly)" Importance="high" />
-    <ILMerge ToolPath="$(ILMergePath)" InputAssemblies="@(MergeAsm)" OutputFile="$(MergedAssembly)" TargetKind="SameAsPrimaryAssembly" KeyFile="$(CertificateTmpPubFile)" DelaySign="true" />
+    <ILMerge ToolPath="$(ILMergePath)" InputAssemblies="@(MergeAsm)" OutputFile="$(MergedAssembly)" TargetKind="SameAsPrimaryAssembly" KeyFile="$(CertificateTmpPubFile)" DelaySign="true" TargetPlatformVersion="v2" />
     <Exec Command="&quot;$(SNPath)&quot; -R &quot;$(MergedAssembly)&quot; &quot;$(AssemblyOriginatorKeyFile)&quot;" />
   </Target>
 </Project>

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -172,7 +172,7 @@
     <Message Text="Extracting public key from $(AssemblyOriginatorKeyFile)" />
     <Exec Command="&quot;$(SNPath)&quot; -p &quot;$(AssemblyOriginatorKeyFile)&quot; &quot;$(CertificateTmpPubFile)&quot;" />
     <Message Text="ILMerge @(MergeAsm) -&gt; $(MergedAssembly)" Importance="high" />
-    <ILMerge ToolPath="$(ILMergePath)" InputAssemblies="@(MergeAsm)" OutputFile="$(MergedAssembly)" TargetKind="SameAsPrimaryAssembly" KeyFile="$(CertificateTmpPubFile)" DelaySign="true" TargetPlatformVersion="v2" />
+    <ILMerge ToolPath="$(ILMergePath)" InputAssemblies="@(MergeAsm)" OutputFile="$(MergedAssembly)" TargetKind="SameAsPrimaryAssembly" KeyFile="$(CertificateTmpPubFile)" DelaySign="true" />
     <Exec Command="&quot;$(SNPath)&quot; -R &quot;$(MergedAssembly)&quot; &quot;$(AssemblyOriginatorKeyFile)&quot;" />
   </Target>
 </Project>

--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -22,23 +22,23 @@ namespace winsw.Util
         /// <returns>List of child process PIDs</returns>
         public static List<int> GetChildPids(int pid)
         {
-			var childPids = new List<int>();
-			
-			try {
-				var searcher = new ManagementObjectSearcher("Select * From Win32_Process Where ParentProcessID=" + pid);
-				foreach (var mo in searcher.Get())
-				{
-					var childProcessId = mo["ProcessID"];
-					Logger.Info("Found child process: " + childProcessId + " Name: " + mo["Name"]);
-					childPids.Add(Convert.ToInt32(childProcessId));
-				}
-			}
-			catch (Exception ex)
+            var childPids = new List<int>();
+            
+            try {
+                var searcher = new ManagementObjectSearcher("Select * From Win32_Process Where ParentProcessID=" + pid);
+                foreach (var mo in searcher.Get())
+                {
+                    var childProcessId = mo["ProcessID"];
+                    Logger.Info("Found child process: " + childProcessId + " Name: " + mo["Name"]);
+                    childPids.Add(Convert.ToInt32(childProcessId));
+                }
+            }
+            catch (Exception ex)
             {
                 Logger.Warn("Failed to locate children of the process with PID=" + pid + ". Child processes won't be terminated", ex);
             }
             
-			return childPids;
+            return childPids;
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace winsw.Util
         /// <param name="stopParentProcessFirst">If enabled, the perent process will be terminated before its children on all levels</param>
         public static void StopProcessAndChildren(int pid, TimeSpan stopTimeout, bool stopParentProcessFirst)
         {
-			if (!stopParentProcessFirst)
+            if (!stopParentProcessFirst)
             {         
                 foreach (var childPid in GetChildPids(pid))
                 {

--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -22,15 +22,23 @@ namespace winsw.Util
         /// <returns>List of child process PIDs</returns>
         public static List<int> GetChildPids(int pid)
         {
-            var searcher = new ManagementObjectSearcher("Select * From Win32_Process Where ParentProcessID=" + pid);
-            var childPids = new List<int>();
-            foreach (var mo in searcher.Get())
+			var childPids = new List<int>();
+			
+			try {
+				var searcher = new ManagementObjectSearcher("Select * From Win32_Process Where ParentProcessID=" + pid);
+				foreach (var mo in searcher.Get())
+				{
+					var childProcessId = mo["ProcessID"];
+					Logger.Info("Found child process: " + childProcessId + " Name: " + mo["Name"]);
+					childPids.Add(Convert.ToInt32(childProcessId));
+				}
+			}
+			catch (Exception ex)
             {
-                var childProcessId = mo["ProcessID"];
-                Logger.Info("Found child process: " + childProcessId + " Name: " + mo["Name"]);
-                childPids.Add(Convert.ToInt32(childProcessId));
+                Logger.Warn("Failed to locate children of the process with PID=" + pid + ". Child processes won't be terminated", ex);
             }
-            return childPids;
+            
+			return childPids;
         }
 
         /// <summary>
@@ -90,19 +98,9 @@ namespace winsw.Util
         /// <param name="stopParentProcessFirst">If enabled, the perent process will be terminated before its children on all levels</param>
         public static void StopProcessAndChildren(int pid, TimeSpan stopTimeout, bool stopParentProcessFirst)
         {
-            List<int> childPids = null;
-            try
-            {
-                childPids = GetChildPids(pid);
-            }
-            catch (Exception ex)
-            {
-                Logger.Warn("Failed to locate children of the process with PID=" + pid + ". Child processes won't be terminated", ex);
-            }
-
-            if (!stopParentProcessFirst && childPids != null)
-            {  
-                foreach (var childPid in childPids)
+			if (!stopParentProcessFirst)
+            {         
+                foreach (var childPid in GetChildPids(pid))
                 {
                     StopProcessAndChildren(childPid, stopTimeout, stopParentProcessFirst);
                 }
@@ -110,9 +108,9 @@ namespace winsw.Util
 
             StopProcess(pid, stopTimeout);
 
-            if (stopParentProcessFirst && childPids != null)
+            if (stopParentProcessFirst)
             {
-                foreach (var childPid in childPids)
+                foreach (var childPid in GetChildPids(pid))
                 {
                     StopProcessAndChildren(childPid, stopTimeout, stopParentProcessFirst);
                 }

--- a/src/Core/WinSWCore/Util/SigIntHelper.cs
+++ b/src/Core/WinSWCore/Util/SigIntHelper.cs
@@ -49,6 +49,9 @@ namespace winsw.Util
 
                 process.WaitForExit((int)shutdownTimeout.TotalMilliseconds);
 
+                // Detach from console. Causes child console process to be automatically closed.
+                FreeConsole();
+				
                 return process.HasExited;    
             }
          

--- a/src/Core/WinSWCore/Util/SigIntHelper.cs
+++ b/src/Core/WinSWCore/Util/SigIntHelper.cs
@@ -1,11 +1,15 @@
-﻿using System;
+﻿using log4net;
+using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using winsw.Native;
 
 namespace winsw.Util
 {
     public static class SigIntHelper
     {
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(SigIntHelper));
+
         private const string KERNEL32 = "kernel32.dll";
 
         [DllImport(KERNEL32, SetLastError = true)]
@@ -50,8 +54,13 @@ namespace winsw.Util
                 process.WaitForExit((int)shutdownTimeout.TotalMilliseconds);
 
                 // Detach from console. Causes child console process to be automatically closed.
-                FreeConsole();
-				
+                bool success = FreeConsole();
+                if (!success)
+                {
+                    long errorCode = Kernel32.GetLastError();
+                    Logger.Warn("Failed to detach from console. Error code: " + errorCode);
+                }
+
                 return process.HasExited;    
             }
          


### PR DESCRIPTION
Java application and child conhost process should both gracefully shut down, without kill or warnings. Changelist description below.

Detach from console process after sending SIGINT to java.
Note: we still need `<stopparentprocessfirst>` to be set to true, so the
parent (java) process is shut down first.
Moved exception handling to GetChildPids.
StopProcessAndChildren now gets a fresh list of childPids after stopping
a parent process, as that may have caused some child processes to
terminate.