### PR TITLE
Issue #126 - Add support of authentication in the download settings

### DIFF
--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -147,8 +147,33 @@ This feature should be used only for debugging, as some operating systems and ha
 This optional element can be specified multiple times to have the service wrapper retrieve resources from URL and place it locally as a file.
 This operation runs when the service is started, before the application specified by `<executable>` is launched.
 
+For servers requiring authentication some parameters must be specified depending on the type of authentication. Only the basic authentication requires additional sub-parameters. Supported authentication types are:
+
+* `none`:  default, must not be specified
+* `sspi`: Microsoft [authentication](https://en.wikipedia.org/wiki/Security_Support_Provider_Interface) including Kerberos, NTLM etc. 
+* `basic`: Basic authentication, sub-parameters:
+	* `username=“UserName”`
+	* `password=“Passw0rd”`
+    * `unsecureAuth=“enabled”: default=“disabled"`
+
+The parameter “unsecureAuth” is only effective when the transfer protocol is http - unencrypted data transfer. This is a security vulnerability because the credentials are send in clear text! For a SSPI authentication this is not relevant because the authentication tokens are encrypted.
 ```
-    <download from="http://example.com/some.dat" to="%BASE%\some.dat"/>
+    <download from="https://example.com/some.dat" to="%BASE%\some.dat"
+              auth="sspi"
+              />
+
+    <download from="https://example.com/some.dat" to="%BASE%\some.dat"
+              auth="basic"
+              username="aUser"
+              password="aPassw0rd"
+              />
+
+    <download from="http://example.com/some.dat" to="%BASE%\some.dat"
+              auth="basic"
+              username="aUser"
+              password=“aPassw0rd"
+              unsecureAuth=“enabled”
+              />
 ```
 
 This is another useful building block for developing a self-updating service.

--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -157,6 +157,8 @@ For servers requiring authentication some parameters must be specified depending
 	* `unsecureAuth=“enabled”: default=“disabled"`
 
 The parameter “unsecureAuth” is only effective when the transfer protocol is HTTP - unencrypted data transfer. This is a security vulnerability because the credentials are send in clear text! For a SSPI authentication this is not relevant because the authentication tokens are encrypted.
+
+For target servers using the HTTPS transfer protocol it is necessary, that the CA which issued the server certificate is trusted by the client. This is normally the situation when the server ist located in the Internet. When an organisation is using a self issued CA for the intranet this probably is not the case. In this case it is necessary to import the CA to the Certificate MMC of the Windows client. Have a look to the  instructions on this [site](https://msdn.microsoft.com/de-de/library/system.net.credentialcache.defaultcredentials(v=vs.85).aspx). The self issued CA must be imported to the Trusted Root Certification Authorities for the computer.
 ```
     <download from="http://example.com/some.dat" to="%BASE%\some.dat" />
 

--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -154,26 +154,20 @@ For servers requiring authentication some parameters must be specified depending
 * `basic`: Basic authentication, sub-parameters:
 	* `username=“UserName”`
 	* `password=“Passw0rd”`
-    * `unsecureAuth=“enabled”: default=“disabled"`
+	* `unsecureAuth=“enabled”: default=“disabled"`
 
-The parameter “unsecureAuth” is only effective when the transfer protocol is http - unencrypted data transfer. This is a security vulnerability because the credentials are send in clear text! For a SSPI authentication this is not relevant because the authentication tokens are encrypted.
+The parameter “unsecureAuth” is only effective when the transfer protocol is HTTP - unencrypted data transfer. This is a security vulnerability because the credentials are send in clear text! For a SSPI authentication this is not relevant because the authentication tokens are encrypted.
 ```
-    <download from="https://example.com/some.dat" to="%BASE%\some.dat"
-              auth="sspi"
-              />
+    <download from="http://example.com/some.dat" to="%BASE%\some.dat" />
+
+    <download from="https://example.com/some.dat" to="%BASE%\some.dat" auth="sspi" />
 
     <download from="https://example.com/some.dat" to="%BASE%\some.dat"
-              auth="basic"
-              username="aUser"
-              password="aPassw0rd"
-              />
+              auth="basic" username="aUser" password="aPassw0rd" />
 
     <download from="http://example.com/some.dat" to="%BASE%\some.dat"
-              auth="basic"
-              username="aUser"
-              password=“aPassw0rd"
-              unsecureAuth=“enabled”
-              />
+              auth="basic" unsecureAuth=“enabled”
+              username="aUser" password=“aPassw0rd" />
 ```
 
 This is another useful building block for developing a self-updating service.

--- a/examples/sample-allOptions.xml
+++ b/examples/sample-allOptions.xml
@@ -252,6 +252,18 @@ SECTION: Environment setup
   <!--
   <download from="http://www.google.com/" to="%BASE%\index.html" />
   <download from="http://www.nosuchhostexists.com/" to="%BASE%\dummy.html" />
+
+  An example for unsecure Basic authentication because the connection is not encrypted:
+  <download from="http://example.com/some.dat" to="%BASE%\some.dat"
+            auth="basic" unsecureAuth=“enabled”
+            username="aUser" password=“aPassw0rd" />
+
+  Secure Basic authentication via HTTPS:
+  <download from="https://example.com/some.dat" to="%BASE%\some.dat"
+            auth="basic" username="aUser" password="aPassw0rd" />
+
+  Secure authentication when the target server and the client are members of domain:
+  <download from="https://example.com/some.dat" to="%BASE%\some.dat" auth="sspi" />
   -->
 
 <!-- 

--- a/src/Core/WinSWCore/Download.cs
+++ b/src/Core/WinSWCore/Download.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net;
 using System.Xml;
@@ -23,6 +23,10 @@ namespace winsw
         public void Perform()
         {
             WebRequest req = WebRequest.Create(From);
+            req.UseDefaultCredentials = true;
+            req.PreAuthenticate = true;
+            req.Credentials = CredentialCache.DefaultCredentials;
+
             WebResponse rsp = req.GetResponse();
             FileStream tmpstream = new FileStream(To + ".tmp", FileMode.Create);
             CopyStream(rsp.GetResponseStream(), tmpstream);

--- a/src/Core/WinSWCore/Download.cs
+++ b/src/Core/WinSWCore/Download.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Text;
 using System.Xml;
 
 namespace winsw
@@ -11,21 +12,90 @@ namespace winsw
     /// </summary>
     public class Download
     {
+        public enum AuthType { none = 0, sspi, basic }
+
         public readonly string From;
         public readonly string To;
+        public readonly AuthType Auth = AuthType.none;
+        public readonly string Username;
+        public readonly string Password;
+        public readonly bool UnsecureAuth = false;
 
         internal Download(XmlNode n)
         {
             From = Environment.ExpandEnvironmentVariables(n.Attributes["from"].Value);
             To = Environment.ExpandEnvironmentVariables(n.Attributes["to"].Value);
+
+            string tmpStr = "";
+            try
+            {
+                tmpStr = Environment.ExpandEnvironmentVariables(n.Attributes["auth"].Value);
+            }
+            catch (Exception)
+            {
+            }
+            Auth = tmpStr != "" ? (AuthType)Enum.Parse(typeof(AuthType), tmpStr) : AuthType.none;
+
+            try
+            {
+                tmpStr = Environment.ExpandEnvironmentVariables(n.Attributes["username"].Value);
+            }
+            catch (Exception)
+            {
+            }
+            Username = tmpStr;
+
+            try
+            {
+                tmpStr = Environment.ExpandEnvironmentVariables(n.Attributes["password"].Value);
+            }
+            catch (Exception)
+            {
+            }
+            Password = tmpStr;
+
+            try
+            {
+                tmpStr = Environment.ExpandEnvironmentVariables(n.Attributes["unsecureAuth"].Value);
+            }
+            catch (Exception)
+            {
+            }
+            UnsecureAuth = tmpStr == "enable" ? true : false;
+
+            if (Auth == AuthType.basic)
+            {
+                if (From.StartsWith("http:") && UnsecureAuth == false)
+                {
+                    throw new Exception("Warning: you're sendig your credentials in clear text to the server. If you really want this you must enable this in the configuration!");
+                }
+            }
+        }
+
+        // Source: http://stackoverflow.com/questions/2764577/forcing-basic-authentication-in-webrequest
+        public void SetBasicAuthHeader(WebRequest request, String username, String password)
+        {
+            string authInfo = username + ":" + password;
+            authInfo = Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes(authInfo));
+            request.Headers["Authorization"] = "Basic " + authInfo;
         }
 
         public void Perform()
         {
             WebRequest req = WebRequest.Create(From);
-            req.UseDefaultCredentials = true;
-            req.PreAuthenticate = true;
-            req.Credentials = CredentialCache.DefaultCredentials;
+
+            switch (Auth)
+            {
+                case AuthType.sspi:
+                    req.UseDefaultCredentials = true;
+                    req.PreAuthenticate = true;
+                    req.Credentials = CredentialCache.DefaultCredentials;
+                    break;
+
+                case AuthType.basic:
+                    SetBasicAuthHeader(req, Username, Password);
+                    break;
+            }
 
             WebResponse rsp = req.GetResponse();
             FileStream tmpstream = new FileStream(To + ".tmp", FileMode.Create);

--- a/src/Core/WinSWCore/Download.cs
+++ b/src/Core/WinSWCore/Download.cs
@@ -67,7 +67,7 @@ namespace winsw
             {
                 if (From.StartsWith("http:") && UnsecureAuth == false)
                 {
-                    throw new Exception("Warning: you're sendig your credentials in clear text to the server. If you really want this you must enable this in the configuration!");
+                    throw new Exception("Warning: you're sending your credentials in clear text to the server. If you really want this you must enable this in the configuration!");
                 }
             }
         }

--- a/src/Core/WinSWCore/Download.cs
+++ b/src/Core/WinSWCore/Download.cs
@@ -61,7 +61,7 @@ namespace winsw
             catch (Exception)
             {
             }
-            UnsecureAuth = tmpStr == "enable" ? true : false;
+            UnsecureAuth = tmpStr == "enabled" ? true : false;
 
             if (Auth == AuthType.basic)
             {


### PR DESCRIPTION
This code adds authentication handling for downloads from  a server
which requires this. [Source](http://stackoverflow.com/questions/5572588/webrequest-getresponse-is-throwing-error-401-unauthorized).

I tested the functionality with a Jenkins instance using the plugin "HTTP Header by reverse proxy" and an Apache 2.4 with Kerberos authentication (mod_auth_kerb 5.4). Another check was to "disable" any authentication that no credentials were required (Apache "Require all granted").

The service was created on Windows server 2008 with bind to a domain account.