### PR TITLE
[JENKINS-42744] - Prevent conversion of environment variables to lowercase

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -400,11 +400,11 @@ namespace winsw
 
         private void StartProcess(Process processToStart, string arguments, String executable)
         {
-            string msg = processToStart.Id + " - " + processToStart.StartInfo.FileName + " " + processToStart.StartInfo.Arguments;
-
+            
             // Define handler of the completed process
             ProcessCompletionCallback processCompletionCallback = delegate(Process proc)
             {
+                string msg = processToStart.Id + " - " + processToStart.StartInfo.FileName + " " + processToStart.StartInfo.Arguments;
                 try
                 {
                     if (_orderlyShutdown)

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -134,25 +134,6 @@ namespace winsw
         }
 
         /// <summary>
-        /// Starts a thread that protects the execution with a try/catch block.
-        /// It appears that in .NET, unhandled exception in any thread causes the app to terminate
-        /// http://msdn.microsoft.com/en-us/library/ms228965.aspx
-        /// </summary>
-        private void StartThread(ThreadStart main)
-        {
-            new Thread(delegate() {
-                try
-                {
-                    main();
-                }
-                catch (Exception e)
-                {
-                    Log.Error("Thread failed unexpectedly",e);
-                }
-            }).Start();
-        }
-
-        /// <summary>
         /// Handle the creation of the logfiles based on the optional logmode setting.
         /// </summary>
         private void HandleLogfiles()
@@ -419,53 +400,26 @@ namespace winsw
 
         private void StartProcess(Process processToStart, string arguments, String executable)
         {
-            var ps = processToStart.StartInfo;
-            ps.FileName = executable;
-            ps.Arguments = arguments;
-            ps.WorkingDirectory = _descriptor.WorkingDirectory;
-            ps.CreateNoWindow = false;
-            ps.UseShellExecute = false;
-            ps.RedirectStandardInput = true; // this creates a pipe for stdin to the new process, instead of having it inherit our stdin.
-            ps.RedirectStandardOutput = true;
-            ps.RedirectStandardError = true;
+            string msg = processToStart.Id + " - " + processToStart.StartInfo.FileName + " " + processToStart.StartInfo.Arguments;
 
-            foreach (string key in _envs.Keys)
+            // Define handler of the completed process
+            ProcessCompletionCallback processCompletionCallback = delegate(Process proc)
             {
-                Environment.SetEnvironmentVariable(key, _envs[key]);
-                // ps.EnvironmentVariables[key] = envs[key]; // bugged (lower cases all variable names due to StringDictionary being used, see http://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=326163)
-            }
-
-            // TODO: Make it generic via extension points. The issue mentioned above should be ideally worked around somehow
-            ps.EnvironmentVariables[WinSWSystem.ENVVAR_NAME_SERVICE_ID.ToLower()] = _descriptor.Id;
-
-            processToStart.Start();
-            Log.Info("Started " + processToStart.Id);
-
-            var priority = _descriptor.Priority;
-            if (priority != ProcessPriorityClass.Normal)
-                processToStart.PriorityClass = priority;
-
-            // monitor the completion of the process
-            StartThread(delegate
-            {
-                string msg = processToStart.Id + " - " + processToStart.StartInfo.FileName + " " + processToStart.StartInfo.Arguments;
-                processToStart.WaitForExit();
-
                 try
                 {
                     if (_orderlyShutdown)
                     {
-                        LogEvent("Child process [" + msg + "] terminated with " + processToStart.ExitCode, EventLogEntryType.Information);
+                        LogEvent("Child process [" + msg + "] terminated with " + proc.ExitCode, EventLogEntryType.Information);
                     }
                     else
                     {
-                        LogEvent("Child process [" + msg + "] finished with " + processToStart.ExitCode, EventLogEntryType.Warning);
+                        LogEvent("Child process [" + msg + "] finished with " + proc.ExitCode, EventLogEntryType.Warning);
                         // if we finished orderly, report that to SCM.
                         // by not reporting unclean shutdown, we let Windows SCM to decide if it wants to
                         // restart the service automatically
-                        if (processToStart.ExitCode == 0)
+                        if (proc.ExitCode == 0)
                             SignalShutdownComplete();
-                        Environment.Exit(processToStart.ExitCode);
+                        Environment.Exit(proc.ExitCode);
                     }
                 }
                 catch (InvalidOperationException ioe)
@@ -475,13 +429,23 @@ namespace winsw
 
                 try
                 {
-                    processToStart.Dispose();
+                    proc.Dispose();
                 }
                 catch (InvalidOperationException ioe)
                 {
                     LogEvent("Dispose " + ioe.Message);
                 }
-            });
+            };
+
+            // Invoke process and exit
+            ProcessHelper.StartProcessAndCallbackForExit(
+                processToStart: processToStart,
+                executable: executable,
+                arguments: arguments,
+                envVars: _envs,
+                workingDirectory: _descriptor.WorkingDirectory,
+                priority: _descriptor.Priority,
+                callback: processCompletionCallback);
         }
 
         public static int Main(string[] args)

--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -147,14 +147,10 @@ namespace winsw.Util
                 foreach (string key in envVars.Keys)
                 {
                     Environment.SetEnvironmentVariable(key, envVars[key]);
-                    // ps.EnvironmentVariables[key] = envs[key]; // bugged (lower cases all variable names due to StringDictionary being used, see http://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=326163)
+                    // DONTDO: ps.EnvironmentVariables[key] = envs[key]; 
+                    // bugged (lower cases all variable names due to StringDictionary being used, see http://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=326163)
                 }
             }
-
-            //TODO: move outside, stubbed to reproduce the issue
-            // TODO: Make it generic via extension points. The issue mentioned above should be ideally worked around somehow
-            ps.EnvironmentVariables[WinSWSystem.ENVVAR_NAME_SERVICE_ID.ToLower()] = "myapp";// _descriptor.Id;
-            // Environment.SetEnvironmentVariable(WinSWSystem.ENVVAR_NAME_SERVICE_ID.ToLower(), _descriptor.Id);
 
             processToStart.Start();
             Logger.Info("Started process " + processToStart.Id);

--- a/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
+++ b/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
@@ -118,9 +118,10 @@ namespace winsw.Plugins.RunawayProcessKiller
             // TODO: This method is not ideal since it works only for vars explicitly mentioned in the start info
             // No Windows 10- compatible solution for EnvVars retrieval, see https://blog.gapotchenko.com/eazfuscator.net/reading-environment-variables
             StringDictionary previousProcessEnvVars = proc.StartInfo.EnvironmentVariables;
-            String expectedEnvVarName = WinSWSystem.ENVVAR_NAME_SERVICE_ID.ToLower();
+            String expectedEnvVarName = WinSWSystem.ENVVAR_NAME_SERVICE_ID;
             if (previousProcessEnvVars.ContainsKey(expectedEnvVarName))
             {
+                // StringDictionary is case-insensitive, hence it will fetch variable definitions in any case
                 affiliatedServiceId = previousProcessEnvVars[expectedEnvVarName];
             }
             else if (CheckWinSWEnvironmentVariable)

--- a/src/Test/winswTests/Extensions/ExtensionTestBase.cs
+++ b/src/Test/winswTests/Extensions/ExtensionTestBase.cs
@@ -15,7 +15,7 @@ namespace winswTests.Extensions
         /// </summary>
         /// <param name="type">Type of the extension</param>
         /// <returns>String for Type locator, which includes class and assembly names</returns>
-        protected static String getExtensionClassNameWithAssembly(Type type)
+        public static String getExtensionClassNameWithAssembly(Type type)
         {
             return type.ToString() + ", " + type.Assembly;
         }

--- a/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
+++ b/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
@@ -3,6 +3,12 @@ using NUnit.Framework;
 using winsw.Extensions;
 using winsw.Plugins.SharedDirectoryMapper;
 using winsw.Plugins.RunawayProcessKiller;
+using winswTests.Util;
+using System.IO;
+using System.Diagnostics;
+using winsw.Util;
+using System;
+using System.Collections.Generic;
 
 namespace winswTests.Extensions
 {
@@ -57,6 +63,61 @@ namespace winswTests.Extensions
             manager.LoadExtensions();
             manager.FireOnWrapperStarted();
             manager.FireBeforeWrapperStopped();
+        }
+
+        [Test]
+        public void ShouldKillTheSpawnedProcess()
+        {
+            var winswId = "myAppWithRunaway";
+            var extensionId = "runawayProcessKiller";
+            var tmpDir = FilesystemTestHelper.CreateTmpDirectory();
+            
+            // Prepare the env var
+            String varName = WinSWSystem.ENVVAR_NAME_SERVICE_ID;
+            var env = new Dictionary<string, string>();
+            env.Add("varName", winswId);
+
+            // Spawn the test process
+            var scriptFile = Path.Combine(tmpDir, "dosleep.bat");
+            var envFile = Path.Combine(tmpDir, "env.txt");
+            File.WriteAllText(scriptFile, "set > " + envFile + "\nsleep 100500");
+            Process proc = new Process();
+            var ps = proc.StartInfo;
+            ps.FileName = scriptFile;
+            ProcessHelper.StartProcessAndCallbackForExit(proc, envVars: env);
+
+            try
+            {
+                // Generate extension and ensure that the roundtrip is correct
+                var pidfile = Path.Combine(tmpDir, "process.pid");
+                var sd = ConfigXmlBuilder.create(id: winswId).WithRunawayProcessKiller(new RunawayProcessKillerExtension(pidfile), extensionId).ToServiceDescriptor();
+                WinSWExtensionManager manager = new WinSWExtensionManager(sd);
+                manager.LoadExtensions();
+                var extension = manager.Extensions[extensionId] as RunawayProcessKillerExtension;
+                Assert.IsNotNull(extension, "RunawayProcessKillerExtension should be loaded");
+                Assert.AreEqual(pidfile, extension.Pidfile, "PidFile should have been retained during the config roundtrip");
+
+                // Inject PID 
+                File.WriteAllText(pidfile, proc.Id.ToString());
+
+                // Try to terminate
+                Assert.That(!proc.HasExited, "Process " + proc + " has exited before the RunawayProcessKiller extension invocation");
+                extension.OnWrapperStarted();
+                Assert.That(proc.HasExited, "Process " + proc + " should have been terminated by RunawayProcessKiller");
+            }
+            finally
+            {
+                if (!proc.HasExited)
+                {
+                    Console.Error.WriteLine("Test: Killing runaway process with ID=" + proc.Id);
+                    ProcessHelper.StopProcessAndChildren(proc.Id, TimeSpan.FromMilliseconds(100), false);
+                    if (!proc.HasExited)
+                    {
+                        // The test is failed here anyway, but we add additional diagnostics info
+                        Console.Error.WriteLine("Test: ProcessHelper failed to properly terminate process with ID=" + proc.Id);
+                    }
+                }
+            }   
         }
     }
 }

--- a/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
+++ b/src/Test/winswTests/Extensions/RunawayProcessKillerTest.cs
@@ -89,8 +89,11 @@ namespace winswTests.Extensions
             try
             {
                 // Generate extension and ensure that the roundtrip is correct
+                //TODO: checkWinSWEnvironmentVariable should be true, but it does not work due to proc.StartInfo.EnvironmentVariables
                 var pidfile = Path.Combine(tmpDir, "process.pid");
-                var sd = ConfigXmlBuilder.create(id: winswId).WithRunawayProcessKiller(new RunawayProcessKillerExtension(pidfile), extensionId).ToServiceDescriptor();
+                var sd = ConfigXmlBuilder.create(id: winswId)
+                    .WithRunawayProcessKiller(new RunawayProcessKillerExtension(pidfile, checkWinSWEnvironmentVariable: false), extensionId)
+                    .ToServiceDescriptor();
                 WinSWExtensionManager manager = new WinSWExtensionManager(sd);
                 manager.LoadExtensions();
                 var extension = manager.Extensions[extensionId] as RunawayProcessKillerExtension;

--- a/src/Test/winswTests/Util/ConfigXmlBuilder.cs
+++ b/src/Test/winswTests/Util/ConfigXmlBuilder.cs
@@ -113,6 +113,7 @@ namespace winswTests.Util
             str.AppendFormat("      <pidfile>{0}</pidfile>\n", ext.Pidfile);
             str.AppendFormat("      <stopTimeout>{0}</stopTimeout>\n", ext.StopTimeout.TotalMilliseconds);
             str.AppendFormat("      <stopParentFirst>{0}</stopParentFirst>\n", ext.StopParentProcessFirst);
+            str.AppendFormat("      <checkWinSWEnvironmentVariable>{0}</checkWinSWEnvironmentVariable>\n", ext.CheckWinSWEnvironmentVariable);
             str.Append(      "    </extension>\n");
             ExtensionXmls.Add(str.ToString());
 

--- a/src/Test/winswTests/Util/ConfigXmlBuilder.cs
+++ b/src/Test/winswTests/Util/ConfigXmlBuilder.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Text;
 using winsw;
+using winsw.Plugins.RunawayProcessKiller;
+using winswTests.Extensions;
 
 namespace winswTests.Util
 {
@@ -16,6 +18,7 @@ namespace winswTests.Util
         public string Executable { get; set; }
         public bool PrintXMLVersion { get; set; }
         public string XMLComment  { get; set; }
+        public List<string> ExtensionXmls { get; private set; }
 
         private List<String> configEntries;
 
@@ -23,6 +26,7 @@ namespace winswTests.Util
         private ConfigXmlBuilder()
         {
             configEntries = new List<string>();
+            ExtensionXmls = new List<string>();
         }
 
         public static ConfigXmlBuilder create(string id = null, string name = null, 
@@ -63,6 +67,18 @@ namespace winswTests.Util
                 // We do not care much about pretty formatting here
                 str.AppendFormat("  {0}\n", entry);
             }
+
+            // Extensions
+            if (ExtensionXmls.Count > 0) 
+            {
+                str.Append("  <extensions>\n");
+                foreach (string xml in ExtensionXmls) 
+                {
+                    str.Append(xml);
+                }
+                str.Append("  </extensions>\n");
+            }
+
             str.Append("</service>\n");
             string res = str.ToString();
             if (dumpConfig)
@@ -87,6 +103,20 @@ namespace winswTests.Util
         public ConfigXmlBuilder WithTag(string tagName, string value)
         { 
             return WithRawEntry(String.Format("<{0}>{1}</{0}>", tagName, value));
+        }
+
+        public ConfigXmlBuilder WithRunawayProcessKiller(RunawayProcessKillerExtension ext, string extensionId = "killRunawayProcess", bool enabled = true)
+        {
+            var fullyQualifiedExtensionName = ExtensionTestBase.getExtensionClassNameWithAssembly(typeof(RunawayProcessKillerExtension));
+            StringBuilder str = new StringBuilder();
+            str.AppendFormat("    <extension enabled=\"{0}\" className=\"{1}\" id=\"{2}\">\n", new Object[] { enabled, fullyQualifiedExtensionName, extensionId});  
+            str.AppendFormat("      <pidfile>{0}</pidfile>\n", ext.Pidfile);
+            str.AppendFormat("      <stopTimeout>{0}</stopTimeout>\n", ext.StopTimeout.TotalMilliseconds);
+            str.AppendFormat("      <stopParentFirst>{0}</stopParentFirst>\n", ext.StopParentProcessFirst);
+            str.Append(      "    </extension>\n");
+            ExtensionXmls.Add(str.ToString());
+
+            return this;
         }
     }
 }

--- a/src/Test/winswTests/Util/FilesystemTestHelper.cs
+++ b/src/Test/winswTests/Util/FilesystemTestHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -29,7 +30,15 @@ namespace winswTests.Util
             Dictionary<string, string> res = new Dictionary<string, string>();
             var lines = File.ReadAllLines(filePath);
             foreach(var line in lines) {
-                line.Split("=".ToCharArray(), 2);
+                var parsed = line.Split("=".ToCharArray(), 2);
+                if (parsed.Length == 2)
+                {
+                    res.Add(parsed[0], parsed[1]);
+                }
+                else
+                {
+                    Assert.Fail("Wrong line in the parsed Set output file: " + line);
+                }
             }
             return res;
         }

--- a/src/Test/winswTests/Util/FilesystemTestHelper.cs
+++ b/src/Test/winswTests/Util/FilesystemTestHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace winswTests.Util
+{
+    class FilesystemTestHelper
+    {
+        /// <summary>
+        /// Creates a temporary directory for testing.
+        /// </summary>
+        /// <returns>tmp Dir</returns>
+        public static string CreateTmpDirectory(String testName = null)
+        {
+            string tempDirectory = Path.Combine(Path.GetTempPath(), "winswTests_" + (testName ?? "") + Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDirectory);
+            Console.Out.WriteLine("Created the temporary directory: {0}", tempDirectory);
+            return tempDirectory;
+        }
+
+        /// <summary>
+        /// Parses output of the "set" command from the file
+        /// </summary>
+        /// <param name="filePath">File path</param>
+        /// <returns>Dictionary of the strings.</returns>
+        public static Dictionary<string, string> parseSetOutput(string filePath)
+        {
+            Dictionary<string, string> res = new Dictionary<string, string>();
+            var lines = File.ReadAllLines(filePath);
+            foreach(var line in lines) {
+                line.Split("=".ToCharArray(), 2);
+            }
+            return res;
+        }
+    }
+}

--- a/src/Test/winswTests/Util/ProcessHelperTest.cs
+++ b/src/Test/winswTests/Util/ProcessHelperTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Diagnostics;
+using NUnit.Framework;
+using winsw;
+using System.IO;
+using winsw.Util;
+
+namespace winswTests.Util
+{
+
+    [TestFixture]
+    class ProcessHelperTest
+    {
+        /// <summary>
+        /// Also reported as <a href="https://issues.jenkins-ci.org/browse/JENKINS-42744">JENKINS-42744</a>
+        /// </summary>
+        [Test]
+        public void ShouldPropagateVariablesInUppercase()
+        {
+            var tmpDir = FilesystemTestHelper.CreateTmpDirectory();
+            String envFile = Path.Combine(tmpDir, "env.properties");
+            String scriptFile = Path.Combine(tmpDir, "printenv.bat");
+            File.WriteAllText(scriptFile, "set > " + envFile);
+
+
+            Process proc = new Process();
+            var ps = proc.StartInfo;
+            ps.FileName = scriptFile;
+
+            ProcessHelper.StartProcessAndCallbackForExit(proc);
+            var exited = proc.WaitForExit(5000);
+            if (!exited)
+            {
+                Assert.Fail("Process " + proc + " didn't exit after 5 seconds");
+            }
+
+            // Check several veriables, which are expected to be in Uppercase
+            var envVars = FilesystemTestHelper.parseSetOutput(envFile);
+            Assert.That(envVars.ContainsKey("PROCESSOR_ARCHITECTURE"), "No PROCESSOR_ARCHITECTURE in the injected vars");
+            Assert.That(envVars.ContainsKey("COMPUTERNAME"), "No COMPUTERNAME in the injected vars");
+            Assert.That(envVars.ContainsKey("PATHEXT"), "No PATHEXT in the injected vars");
+            
+            // And just ensure that the parsing logic is case-sensitive
+            Assert.That(!envVars.ContainsKey("computername"), "Test error: the environment parsing logic is case-insensitive");
+
+        }
+    }
+}

--- a/src/Test/winswTests/Util/ProcessHelperTest.cs
+++ b/src/Test/winswTests/Util/ProcessHelperTest.cs
@@ -36,9 +36,12 @@ namespace winswTests.Util
 
             // Check several veriables, which are expected to be in Uppercase
             var envVars = FilesystemTestHelper.parseSetOutput(envFile);
-            Assert.That(envVars.ContainsKey("PROCESSOR_ARCHITECTURE"), "No PROCESSOR_ARCHITECTURE in the injected vars");
-            Assert.That(envVars.ContainsKey("COMPUTERNAME"), "No COMPUTERNAME in the injected vars");
-            Assert.That(envVars.ContainsKey("PATHEXT"), "No PATHEXT in the injected vars");
+            String[] keys = new String[envVars.Count];
+            envVars.Keys.CopyTo(keys, 0);
+            String availableVars = "[" + String.Join(",", keys) + "]";
+            Assert.That(envVars.ContainsKey("PROCESSOR_ARCHITECTURE"), "No PROCESSOR_ARCHITECTURE in the injected vars: " + availableVars);
+            Assert.That(envVars.ContainsKey("COMPUTERNAME"), "No COMPUTERNAME in the injected vars: " + availableVars);
+            Assert.That(envVars.ContainsKey("PATHEXT"), "No PATHEXT in the injected vars: " + availableVars);
             
             // And just ensure that the parsing logic is case-sensitive
             Assert.That(!envVars.ContainsKey("computername"), "Test error: the environment parsing logic is case-insensitive");

--- a/src/Test/winswTests/winswTests.csproj
+++ b/src/Test/winswTests/winswTests.csproj
@@ -60,6 +60,8 @@
     <Compile Include="Extensions\RunawayProcessKillerTest.cs" />
     <Compile Include="Extensions\SharedDirectoryMapperTest.cs" />
     <Compile Include="MainTest.cs" />
+    <Compile Include="Util\FilesystemTestHelper.cs" />
+    <Compile Include="Util\ProcessHelperTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServiceDescriptorTests.cs" />
     <Compile Include="Util\CLITestHelper.cs" />


### PR DESCRIPTION
This change intends fixing the regression I've introduced in WinSW 2.0 in https://github.com/kohsuke/winsw/commit/92367f44ef208bca20c6dfcadb975722fd28763d. I have added `ps.EnvironmentVariables[WinSWSystem.ENVVAR_NAME_SERVICE_ID.ToLower()] = _descriptor.Id;`, which made all variables to be in lowercase in the injected process. Some tools were not ready to that though they are expected to handle Env Vars in the case-insensitive mode in Windows. But Java tools do not do that By default, hence [JENKINS-42744](https://issues.jenkins-ci.org/browse/JENKINS-42744) was reported by Jenkins users.

Changes:

- [x] - Fix Issue #201 (JENKINS-42744)
- [x] - Refactor the `Main#StartProcess()` logic to make it testable
- [x] - Add tests for #201 
- [x] - Also add the process termination tests to the `RunawayProcessKiller` to ensure there is no regressions

https://issues.jenkins-ci.org/browse/JENKINS-42744

@reviewbybees