### PR TITLE
#183 - Add core logic for the DelayedStart option support

### DIFF
--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -53,11 +53,25 @@ This gets displayed in Windows service manager when the service is selected.
 This element specifies the executable to be launched. 
 It can be either absolute path, or you can just specify the executable name and let it be searched from `PATH` (although note that the services often run in a different user account and therefore it might have different `PATH` than your shell does.)
 
-### startmode - Optional Element
+### startmode
 This element specifies the start mode of the Windows service. 
 It can be one of the following values: Boot, System, Automatic, or Manual. 
 See [MSDN](https://msdn.microsoft.com/en-us/library/aa384896%28v=vs.85%29.aspx) for details.
 The default value is `Automatic`.
+
+### dalayedstart
+
+This Boolean option enables the delayed start mode if the `Automatic` start mode is defined.
+More information about this mode is provided [here](https://blogs.technet.microsoft.com/askperf/2008/02/02/ws2008-startup-processes-and-delayed-automatic-start/).
+Please note that this startup mode will not take affect on old Windows versions older than Windows 7 and Windows Server 2008.
+
+```xml
+  <delayedstart/>
+```
+
+Note that modern versions of Windows do not correctly reflect the modification of the `DelayedAutoStart` field in _Service Manager_ and _MMC_. 
+After the installation of the service with the `delayedstart` flag, the option will be displayed there only after the system restart. 
+See [this article](https://social.msdn.microsoft.com/Forums/en-US/e5dbfe02-5125-4833-8e6b-3aa3d8518fc8/delayed-start-registry-setting?forum=biztalkgeneral) for more info about this issue.
 
 ### depend
 Specify IDs of other services that this service depends on. 

--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -69,10 +69,6 @@ Please note that this startup mode will not take affect on old Windows versions 
   <delayedstart/>
 ```
 
-Note that modern versions of Windows do not correctly reflect the modification of the `DelayedAutoStart` field in _Service Manager_ and _MMC_. 
-After the installation of the service with the `delayedstart` flag, the option will be displayed there only after the system restart. 
-See [this article](https://social.msdn.microsoft.com/Forums/en-US/e5dbfe02-5125-4833-8e6b-3aa3d8518fc8/delayed-start-registry-setting?forum=biztalkgeneral) for more info about this issue.
-
 ### depend
 Specify IDs of other services that this service depends on. 
 When service `X` depends on service `Y`, `X` can only run if `Y` is running.

--- a/doc/xmlConfigFile.md
+++ b/doc/xmlConfigFile.md
@@ -59,14 +59,16 @@ It can be one of the following values: Boot, System, Automatic, or Manual.
 See [MSDN](https://msdn.microsoft.com/en-us/library/aa384896%28v=vs.85%29.aspx) for details.
 The default value is `Automatic`.
 
-### dalayedstart
+### delayedAutoStart
 
 This Boolean option enables the delayed start mode if the `Automatic` start mode is defined.
 More information about this mode is provided [here](https://blogs.technet.microsoft.com/askperf/2008/02/02/ws2008-startup-processes-and-delayed-automatic-start/).
+
 Please note that this startup mode will not take affect on old Windows versions older than Windows 7 and Windows Server 2008.
+Windows service installation may fail in such case.
 
 ```xml
-  <delayedstart/>
+  <delayedAutoStart/>
 ```
 
 ### depend

--- a/examples/sample-allOptions.xml
+++ b/examples/sample-allOptions.xml
@@ -163,11 +163,11 @@ SECTION: Service management
     <startmode>Automatic</startmode>
     
     <!--
-      OPTION: delayedstart
+      OPTION: delayedAutoStart
       Enables the Delayed Automatic Start if 'Automatic' is specified in the 'startmode' field.
       See the WinSW documentation to get info about supported platform versions and limitations.
     -->
-    <!--<delayedstart/>-->
+    <!--<delayedAutoStart/>-->
     
     <!-- 
       OPTION: depend

--- a/examples/sample-allOptions.xml
+++ b/examples/sample-allOptions.xml
@@ -162,6 +162,13 @@ SECTION: Service management
     -->
     <startmode>Automatic</startmode>
     
+    <!--
+      OPTION: delayedstart
+      Enables the Delayed Automatic Start if 'Automatic' is specified in the 'startmode' field.
+      See the WinSW documentation to get info about supported platform versions and limitations.
+    -->
+    <!--<delayedstart/>-->
+    
     <!-- 
       OPTION: depend
       Optionally specifies services that must start before this service starts.

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -605,6 +605,13 @@ namespace winsw
                     Registry.LocalMachine.OpenSubKey("System").OpenSubKey("CurrentControlSet").OpenSubKey("Services")
                         .OpenSubKey(d.Id, true).SetValue("Description", d.Description);
 
+                    if (d.StartMode == StartMode.Automatic && d.DelayedStart)
+                    {
+                        //TODO: replace by a better API after migrating to .NET 4
+                        Registry.LocalMachine.OpenSubKey("System").OpenSubKey("CurrentControlSet").OpenSubKey("Services")
+                            .OpenSubKey(d.Id, true).SetValue("DelayedAutoStart", 1);
+                    }
+
                     var actions = d.FailureActions;
                     if (actions.Count > 0)
                     {// set the failure actions

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -606,7 +606,7 @@ namespace winsw
                         .OpenSubKey(d.Id, true).SetValue("Description", d.Description);
 
                     var actions = d.FailureActions;
-                    var isDelayedAutoStart = d.StartMode == StartMode.Automatic && d.DelayedStart;
+                    var isDelayedAutoStart = d.StartMode == StartMode.Automatic && d.DelayedAutoStart;
                     if (actions.Count > 0 || isDelayedAutoStart)
                     {
                         using (ServiceManager scm = new ServiceManager())

--- a/src/Core/WinSWCore/Configuration/DefaultSettings.cs
+++ b/src/Core/WinSWCore/Configuration/DefaultSettings.cs
@@ -49,7 +49,7 @@ namespace winsw.Configuration
 
         // Service management
         public StartMode StartMode { get { return StartMode.Automatic; } }
-        public bool DelayedStart { get { return false; } }
+        public bool DelayedAutoStart { get { return false; } }
         public string[] ServiceDependencies { get { return new string[0]; } }
         public TimeSpan WaitHint { get { return TimeSpan.FromSeconds(15); } }
         public TimeSpan SleepTime { get { return TimeSpan.FromSeconds(1); } }

--- a/src/Core/WinSWCore/Configuration/DefaultSettings.cs
+++ b/src/Core/WinSWCore/Configuration/DefaultSettings.cs
@@ -49,6 +49,7 @@ namespace winsw.Configuration
 
         // Service management
         public StartMode StartMode { get { return StartMode.Automatic; } }
+        public bool DelayedStart { get { return false; } }
         public string[] ServiceDependencies { get { return new string[0]; } }
         public TimeSpan WaitHint { get { return TimeSpan.FromSeconds(15); } }
         public TimeSpan SleepTime { get { return TimeSpan.FromSeconds(1); } }

--- a/src/Core/WinSWCore/Native/Advapi32.cs
+++ b/src/Core/WinSWCore/Native/Advapi32.cs
@@ -79,6 +79,26 @@ namespace winsw.Native
             }
         }
 
+        /// <summary>
+        /// Sets the DelayedAutoStart flag.
+        /// It will be applioed to services with Automatic startup mode only.
+        /// If the platform does not support this flag, an exception may be thrown.
+        /// </summary>
+        /// <param name="enabled">Value to set</param>
+        /// <exception cref="Exception">Operation failure, e.g. the OS does not support this flag</exception>
+        public void SetDelayedAutoStart(bool enabled)
+        {
+            SERVICE_DELAYED_AUTO_START settings = new SERVICE_DELAYED_AUTO_START
+            {
+                fDelayedAutostart = enabled
+            };
+
+            if (!Advapi32.ChangeServiceConfig2(Handle, SERVICE_CONFIG_INFOLEVEL.SERVICE_CONFIG_DELAYED_AUTO_START_INFO, ref settings))
+            {
+                throw new Exception("Failed to change the DelayedAutoStart setting", new Win32Exception());
+            }
+        }
+
         public void Dispose()
         {
             if (Handle!=IntPtr.Zero)
@@ -260,6 +280,10 @@ namespace winsw.Native
         [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool ChangeServiceConfig2(IntPtr hService, SERVICE_CONFIG_INFOLEVEL dwInfoLevel, ref SERVICE_FAILURE_ACTIONS sfa);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool ChangeServiceConfig2(IntPtr hService, SERVICE_CONFIG_INFOLEVEL dwInfoLevel, ref SERVICE_DELAYED_AUTO_START sfa);
 
         [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern IntPtr OpenSCManager(string machineName, string databaseName, uint dwAccess);
@@ -568,5 +592,13 @@ namespace winsw.Native
         public string lpCommand;
         public int cActions;
         public IntPtr/*SC_ACTION[]*/ lpsaActions;
+    }
+
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms685155(v=vs.85).aspx
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct SERVICE_DELAYED_AUTO_START
+    {
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool fDelayedAutostart;
     }
 }

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -479,11 +479,11 @@ namespace winsw
         /// True if the service should be installed with the DelayedAutoStart flag.
         /// This setting will be applyed only during the install command and only when the Automatic start mode is configured.
         /// </summary>
-        public bool DelayedStart
+        public bool DelayedAutoStart
         {
             get
             {
-                return dom.SelectSingleNode("//delayedstart") != null;
+                return dom.SelectSingleNode("//delayedAutoStart") != null;
             }
         }
 

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -476,6 +476,19 @@ namespace winsw
         }
 
         /// <summary>
+        /// True if the service should be installed with the DelayedAutoStart flag.
+        /// This setting will be applyed only during the install command and only when the Automatic start mode is configured.
+        /// It does not get reliably applied in Services and MMC UI, see https://social.msdn.microsoft.com/Forums/en-US/e5dbfe02-5125-4833-8e6b-3aa3d8518fc8/delayed-start-registry-setting?forum=biztalkgeneral
+        /// </summary>
+        public bool DelayedStart
+        {
+            get
+            {
+                return dom.SelectSingleNode("//delayedstart") != null;
+            }
+        }
+
+        /// <summary>
         /// True if the service should beep when finished on shutdown.
         /// This doesn't work on some OSes. See http://msdn.microsoft.com/en-us/library/ms679277%28VS.85%29.aspx
         /// </summary>

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -478,7 +478,6 @@ namespace winsw
         /// <summary>
         /// True if the service should be installed with the DelayedAutoStart flag.
         /// This setting will be applyed only during the install command and only when the Automatic start mode is configured.
-        /// It does not get reliably applied in Services and MMC UI, see https://social.msdn.microsoft.com/Forums/en-US/e5dbfe02-5125-4833-8e6b-3aa3d8518fc8/delayed-start-registry-setting?forum=biztalkgeneral
         /// </summary>
         public bool DelayedStart
         {

--- a/src/Test/winswTests/ServiceDescriptorTests.cs
+++ b/src/Test/winswTests/ServiceDescriptorTests.cs
@@ -355,5 +355,17 @@ namespace winswTests
                 .ToServiceDescriptor(true);
             Assert.That(sd.Arguments, Is.EqualTo(" --arg2=123 --arg3=null"));
         }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DelayedStart_RoundTrip(bool enabled)
+        {
+            var bldr = ConfigXmlBuilder.create();
+            if (enabled) { 
+                bldr = bldr.WithDelayedStart();
+            }
+             var sd = bldr.ToServiceDescriptor();
+            Assert.That(sd.DelayedStart, Is.EqualTo(enabled));
+        }
     }
 }

--- a/src/Test/winswTests/ServiceDescriptorTests.cs
+++ b/src/Test/winswTests/ServiceDescriptorTests.cs
@@ -362,10 +362,10 @@ namespace winswTests
         {
             var bldr = ConfigXmlBuilder.create();
             if (enabled) { 
-                bldr = bldr.WithDelayedStart();
+                bldr = bldr.WithDelayedAutoStart();
             }
              var sd = bldr.ToServiceDescriptor();
-            Assert.That(sd.DelayedStart, Is.EqualTo(enabled));
+            Assert.That(sd.DelayedAutoStart, Is.EqualTo(enabled));
         }
     }
 }

--- a/src/Test/winswTests/Util/ConfigXmlBuilder.cs
+++ b/src/Test/winswTests/Util/ConfigXmlBuilder.cs
@@ -144,5 +144,10 @@ namespace winswTests.Util
 
             return WithRawEntry(str.ToString());
         }
+
+        public ConfigXmlBuilder WithDelayedStart()
+        {
+            return WithRawEntry("<delayedstart/>");
+        }
     }
 }

--- a/src/Test/winswTests/Util/ConfigXmlBuilder.cs
+++ b/src/Test/winswTests/Util/ConfigXmlBuilder.cs
@@ -145,9 +145,9 @@ namespace winswTests.Util
             return WithRawEntry(str.ToString());
         }
 
-        public ConfigXmlBuilder WithDelayedStart()
+        public ConfigXmlBuilder WithDelayedAutoStart()
         {
-            return WithRawEntry("<delayedstart/>");
+            return WithRawEntry("<delayedAutoStart/>");
         }
     }
 }


### PR DESCRIPTION
Fixes #183 . The only problem is that MMC and Service are too smart and cache the option internally (see [this article](https://social.msdn.microsoft.com/Forums/en-US/e5dbfe02-5125-4833-8e6b-3aa3d8518fc8/delayed-start-registry-setting?forum=biztalkgeneral)), so the setting does not get displayed there until the system restart.

- [x] - Internal installation logic
- [x] - Documentation update
- [x] - Samples update
- [x] - Functional tests

CC @mtman 