### PR TITLE
Issue #148 - Update log4net to 2.0.8

### DIFF
--- a/src/Core/ServiceWrapper/packages.config
+++ b/src/Core/ServiceWrapper/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="2.14.1208" targetFramework="net20" />
-  <package id="log4net" version="2.0.3" targetFramework="net20" />
+  <package id="log4net" version="2.0.8" targetFramework="net20" />
   <package id="MSBuildTasks" version="1.4.0.88" targetFramework="net20" />
 </packages>

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -63,7 +63,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net20-full\log4net.dll</HintPath>
+      <HintPath>..\..\packages\log4net.2.0.8\lib\net20-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/Core/ServiceWrapper_dotNET4/packages.config
+++ b/src/Core/ServiceWrapper_dotNET4/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="2.14.1208" targetFramework="net20" />
-  <package id="log4net" version="2.0.3" targetFramework="net20" requireReinstallation="True" />
+  <package id="log4net" version="2.0.8" targetFramework="net20" requireReinstallation="True" />
   <package id="MSBuildTasks" version="1.4.0.88" targetFramework="net20" />
 </packages>

--- a/src/Core/ServiceWrapper_dotNET4/winsw_dotNET4.csproj
+++ b/src/Core/ServiceWrapper_dotNET4/winsw_dotNET4.csproj
@@ -64,7 +64,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net20-full\log4net.dll</HintPath>
+      <HintPath>..\..\packages\log4net.2.0.8\lib\net20-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/Core/WinSWCore/WinSWCore.csproj
+++ b/src/Core/WinSWCore/WinSWCore.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net20-full\log4net.dll</HintPath>
+      <HintPath>..\..\packages\log4net.2.0.8\lib\net20-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Core/WinSWCore/packages.config
+++ b/src/Core/WinSWCore/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net20" />
+  <package id="log4net" version="2.0.8" targetFramework="net20" />
 </packages>

--- a/src/Plugins/RunawayProcessKiller/RunawayProcessKiller.csproj
+++ b/src/Plugins/RunawayProcessKiller/RunawayProcessKiller.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net20-full\log4net.dll</HintPath>
+      <HintPath>..\..\packages\log4net.2.0.8\lib\net20-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Plugins/RunawayProcessKiller/packages.config
+++ b/src/Plugins/RunawayProcessKiller/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net20" />
+  <package id="log4net" version="2.0.8" targetFramework="net20" />
 </packages>

--- a/src/Plugins/SharedDirectoryMapper/SharedDirectoryMapper.csproj
+++ b/src/Plugins/SharedDirectoryMapper/SharedDirectoryMapper.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net20-full\log4net.dll</HintPath>
+      <HintPath>..\..\packages\log4net.2.0.8\lib\net20-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Plugins/SharedDirectoryMapper/packages.config
+++ b/src/Plugins/SharedDirectoryMapper/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net20" />
+  <package id="log4net" version="2.0.8" targetFramework="net20" />
 </packages>

--- a/src/Test/winswTests/packages.config
+++ b/src/Test/winswTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="JetBrains.Annotations" version="8.0.5.0" targetFramework="net20" />
-  <package id="log4net" version="2.0.3" targetFramework="net20" />
+  <package id="log4net" version="2.0.8" targetFramework="net20" />
   <package id="NUnit" version="2.6.4" targetFramework="net20" />
 </packages>

--- a/src/Test/winswTests/winswTests.csproj
+++ b/src/Test/winswTests/winswTests.csproj
@@ -47,7 +47,7 @@
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="log4net">
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net20-full\log4net.dll</HintPath>
+      <HintPath>..\..\packages\log4net.2.0.8\lib\net20-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
It effectively bumps the bundled log4net version from 1.2.13 to 2.0.8 (log4net NuGet package used to have different versions). According to the changelogs, there is no expected compatibility issues: 

log4net changelog: https://logging.apache.org/log4net/release/release-notes.html

Addresses #148