### PR TITLE
[Issue #87] - Make logging fully configurable via log4net

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -755,10 +755,9 @@ namespace winsw
         private static void InitLoggers(ServiceDescriptor d, bool enableCLILogging)
         {
             // Ensure that the logging config is not passed from the log4net config file
-            LogHandler handler = d.LogHandler;
-            if (handler is ConfigDefinedLog4NetHandler)
+            if (d.LogHandlerType == LogHandlerType.ConfigDefinedLog4Net)
             {
-                string configPath = ((ConfigDefinedLog4NetHandler)handler).ConfigPath;
+                string configPath = d.Log4NetConfigFilePath;
                 XmlConfigurator.Configure(new System.IO.FileInfo(configPath));
                 return;
             }

--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -754,6 +754,16 @@ namespace winsw
 
         private static void InitLoggers(ServiceDescriptor d, bool enableCLILogging)
         {
+            // Ensure that the logging config is not passed from the log4net config file
+            LogHandler handler = d.LogHandler;
+            if (handler is ConfigDefinedLog4NetHandler)
+            {
+                string configPath = ((ConfigDefinedLog4NetHandler)handler).ConfigPath;
+                XmlConfigurator.Configure(new System.IO.FileInfo(configPath));
+                return;
+            }
+
+
             // TODO: Make logging levels configurable
             Level logLevel = Level.Debug;
             Level eventLogLevel = Level.Warn;

--- a/src/Core/WinSWCore/Logging/Log4NetLogHandler.cs
+++ b/src/Core/WinSWCore/Logging/Log4NetLogHandler.cs
@@ -1,0 +1,100 @@
+﻿using log4net;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace winsw.Logging
+{
+    /// <summary>
+    /// Log Appender for executable STDERR/STDOUT, which passes all logging to log4net.
+    /// </summary>
+    public abstract class Log4NetLogHandlerBase : LogHandler
+    {
+        public bool IndependentErrLog { get; private set; }
+        
+        public ILog Out { get; private set; }
+        public ILog Err { get; private set; }
+
+        public Log4NetLogHandlerBase(bool independentErrLog)
+        {
+            IndependentErrLog = independentErrLog;
+            if (independentErrLog)
+            {
+                Out = LogManager.GetLogger("WinSW.stdout");
+                Err = LogManager.GetLogger("WinSW.stderr");
+            }
+            else
+            {
+                Err = Out = LogManager.GetLogger("WinSW.out");
+            }
+        }
+
+        public override void log(Stream outputStream, Stream errorStream)
+        {
+            new Thread(delegate() { CopyStreamToLogger(outputStream, Out, false); }).Start();
+            new Thread(delegate() { CopyStreamToLogger(errorStream, Err, true); }).Start();
+        }
+
+        /// <summary>
+        /// Convenience method to copy stuff from StreamReader to StreamWriter
+        /// </summary>
+        protected static void CopyStreamToLogger(Stream input, ILog output, bool isErrorLog)
+        {
+            StreamReader stream = new StreamReader(input);
+
+            StringBuilder sb = new StringBuilder();
+            int symbol = stream.Peek();
+            while (symbol != -1)
+            {
+                symbol = stream.Read();
+                if (symbol == 13 && stream.Peek() == 10) // \r\n
+                {
+                    stream.Read();
+                    var line = sb.ToString();
+                    // TODO: any better way to do that without accessing logger?
+                    if (isErrorLog) 
+                    {
+                        output.Error(line);
+                    } 
+                    else 
+                    {
+                        output.Info(line);
+                    }
+                    
+                    // TODO: replace by clear() after adopting newer framework version
+                    sb = new StringBuilder();
+                }
+                else
+                {
+                    sb.Append((char)symbol);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Log handler, which redirects process STDOUT/STDERR to a log4net engine.
+    /// </summary>
+    public class ProcessOnlyLog4NetHandler : Log4NetLogHandlerBase
+    {
+        public ProcessOnlyLog4NetHandler(bool independentErrLog) :
+            base(independentErrLog)
+        {  }
+    }
+
+    /// <summary>
+    /// Log handler, which indicates the entire logging subsystem is configured by a config file.
+    /// </summary>
+    public class ConfigDefinedLog4NetHandler : Log4NetLogHandlerBase
+    {
+        public string ConfigPath { get; private set; }
+
+        public ConfigDefinedLog4NetHandler(bool independentErrLog, string confgPath) :
+            base(independentErrLog)
+        {
+            ConfigPath = confgPath;
+        }
+    }
+}

--- a/src/Core/WinSWCore/Logging/LogHandlerType.cs
+++ b/src/Core/WinSWCore/Logging/LogHandlerType.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace winsw.Logging
+{
+    /// <summary>
+    /// Defines Log Handler types supported in WinSW
+    /// </summary>
+    /// <seealso cref="winsw.LogHandler"/>
+    public enum LogHandlerType
+    {
+        None,
+        Rotate,
+        Reset,
+        Roll,
+        RollByTime,
+        RollBySize,
+        Append,
+        RedirectToLog4Net,
+        ConfigDefinedLog4Net
+    }
+}

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Reflection;
 using System.Xml;
 using winsw.Configuration;
+using winsw.Logging;
 using winsw.Native;
 using winsw.Util;
 using WMI;
@@ -398,6 +399,12 @@ namespace winsw
                     case "append":
                         return new DefaultLogAppender(LogDirectory, BaseName);
 
+                    case "log4net":
+                        string configPath = SingleElement("configPath", true);
+                        // Depending on the config file specification, select proper handler
+                        LogHandler h = (configPath != null) ? (LogHandler) new ConfigDefinedLog4NetHandler(true, configPath) : new ProcessOnlyLog4NetHandler(true);
+                        return h;
+                    
                     default:
                         throw new InvalidDataException("Undefined logging mode: " + LogMode);
                 }

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -54,6 +54,8 @@ namespace winsw
             //Get the first parent to go into the recursive loop
             string p = ExecutablePath;
             string baseName = Path.GetFileNameWithoutExtension(p);
+            BaseName = baseName;
+
             if (baseName.EndsWith(".vshost")) baseName = baseName.Substring(0, baseName.Length - 7);
             DirectoryInfo d = new DirectoryInfo(Path.GetDirectoryName(p));
             while (true)
@@ -67,7 +69,6 @@ namespace winsw
                 d = d.Parent;
             }
 
-            BaseName = baseName;
             BasePath = Path.Combine(d.FullName, BaseName);
 
             dom.Load(BasePath + ".xml");
@@ -356,9 +357,9 @@ namespace winsw
             }
         }
 
-        public LogHandler LogHandler
+        // TODO: refactor and move outside
+        public LogHandlerType LogHandlerType
         {
-            
             get
             {
                 XmlElement e = (XmlElement)dom.SelectSingleNode("//logmode");
@@ -370,18 +371,71 @@ namespace winsw
                 switch (LogMode)
                 {
                     case "rotate":
-                        return new SizeBasedRollingLogAppender(LogDirectory, BaseName);
+                        return Logging.LogHandlerType.Rotate;
 
                     case "none":
-                        return new IgnoreLogAppender();
+                        return Logging.LogHandlerType.None;
 
                     case "reset":
-                        return new ResetLogAppender(LogDirectory, BaseName);
+                        return Logging.LogHandlerType.Reset;
 
                     case "roll":
-                        return new RollingLogAppender(LogDirectory, BaseName);
+                        return Logging.LogHandlerType.Roll;
 
                     case "roll-by-time":
+                        return Logging.LogHandlerType.RollByTime;
+
+                    case "roll-by-size":
+                        return Logging.LogHandlerType.RollBySize;
+
+                    case "append":
+                        return Logging.LogHandlerType.Append;
+
+                    case "log4net":
+                        var configPath = e.SelectSingleNode("configPath");
+                        // Depending on the config file specification, select proper handler
+                        return (configPath != null) ? Logging.LogHandlerType.ConfigDefinedLog4Net : Logging.LogHandlerType.RedirectToLog4Net;
+
+                    default:
+                        throw new InvalidDataException("Undefined logging mode: " + LogMode);
+                }
+            }
+        }
+
+        public string Log4NetConfigFilePath
+        {
+            get
+            {
+                // TODO: ensure the parent is correct
+                return SingleElement("configPath", true);
+            }
+        }
+
+        public LogHandler LogHandler
+        {
+            get
+            {
+                XmlElement e = (XmlElement)dom.SelectSingleNode("//logmode");
+                if (e == null)
+                {
+                    // this is more modern way, to support nested elements as configuration
+                    e = (XmlElement)dom.SelectSingleNode("//log");
+                }
+                switch (LogHandlerType)
+                {
+                    case Logging.LogHandlerType.Rotate:
+                        return new SizeBasedRollingLogAppender(LogDirectory, BaseName);
+
+                    case Logging.LogHandlerType.None:
+                        return new IgnoreLogAppender();
+
+                    case Logging.LogHandlerType.Reset:
+                        return new ResetLogAppender(LogDirectory, BaseName);
+
+                    case Logging.LogHandlerType.Roll:
+                        return new RollingLogAppender(LogDirectory, BaseName);
+
+                    case Logging.LogHandlerType.RollByTime:
                         XmlNode patternNode = e.SelectSingleNode("pattern");
                         if (patternNode == null)
                         {
@@ -391,19 +445,21 @@ namespace winsw
                         int period = SingleIntElement(e,"period",1);
                         return new TimeBasedRollingLogAppender(LogDirectory, BaseName, pattern, period);
 
-                    case "roll-by-size":
+                    case Logging.LogHandlerType.RollBySize:
                         int sizeThreshold = SingleIntElement(e,"sizeThreshold",10*1024)  * SizeBasedRollingLogAppender.BYTES_PER_KB;
                         int keepFiles = SingleIntElement(e,"keepFiles",SizeBasedRollingLogAppender.DEFAULT_FILES_TO_KEEP);
                         return new SizeBasedRollingLogAppender(LogDirectory, BaseName, sizeThreshold, keepFiles);
 
-                    case "append":
+                    case Logging.LogHandlerType.Append:
                         return new DefaultLogAppender(LogDirectory, BaseName);
 
-                    case "log4net":
+                    case Logging.LogHandlerType.RedirectToLog4Net:
+                        return new ProcessOnlyLog4NetHandler(true);
+
+                    case Logging.LogHandlerType.ConfigDefinedLog4Net:
+                        // TODO: ensure the parent is correct
                         string configPath = SingleElement("configPath", true);
-                        // Depending on the config file specification, select proper handler
-                        LogHandler h = (configPath != null) ? (LogHandler) new ConfigDefinedLog4NetHandler(true, configPath) : new ProcessOnlyLog4NetHandler(true);
-                        return h;
+                        return new ConfigDefinedLog4NetHandler(true, configPath);
                     
                     default:
                         throw new InvalidDataException("Undefined logging mode: " + LogMode);

--- a/src/Core/WinSWCore/WinSWCore.csproj
+++ b/src/Core/WinSWCore/WinSWCore.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Configuration\IWinSWConfiguration.cs" />
     <Compile Include="LogAppenders.cs" />
     <Compile Include="Logging\Log4NetLogHandler.cs" />
+    <Compile Include="Logging\LogHandlerType.cs" />
     <Compile Include="Logging\ServiceEventLogAppender.cs" />
     <Compile Include="Logging\IServiceEventLogProvider.cs" />
     <Compile Include="Native\Advapi32.cs" />

--- a/src/Core/WinSWCore/WinSWCore.csproj
+++ b/src/Core/WinSWCore/WinSWCore.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Extensions\WinSWExtensionManager.cs" />
     <Compile Include="Configuration\IWinSWConfiguration.cs" />
     <Compile Include="LogAppenders.cs" />
+    <Compile Include="Logging\Log4NetLogHandler.cs" />
     <Compile Include="Logging\ServiceEventLogAppender.cs" />
     <Compile Include="Logging\IServiceEventLogProvider.cs" />
     <Compile Include="Native\Advapi32.cs" />


### PR DESCRIPTION
Addresses #87 and several other feature requests regarding logging subsystem (#182, #39, #61). Now everybody will be able to configure whatever he wants using the `log4net` logging mode.

Current implementation supports two modes:

1. Redirect STDERR/STDOUT to log4net (Info and Error logging levels)
2. Redirect STDERR/STDOUT to log4net **AND** configure all loggers (CLI, Wrapper log, Event log, STDOUT/STDERR) over a standard [log4net configuration file](https://logging.apache.org/log4net/release/manual/configuration.html)

Mode 1: Redirect STDERR/STDOUT

```xml
  <log mode="log4net"/>
```

Mode 2: Full configuration via config file

```xml
  <log mode="log4net">
	<configPath>%BASE%\log4net.xml</configPath>
  </log>
```

TODOs:
- [x] - First prototype
- [ ] - rework PoC to have two separate logging mode names
- [ ] - Get feedback from users and requesters
- [ ] - Polish/refactor the implementation
- [ ] - Documentation
- [ ] - Functional tests

Test build will be available from AppVeyor. CC @aminjam , @roederja2 , @maurokade, @Randy1967, @pvandervelde 