### PR TITLE
[Issue #218] StdOut was not being redirected properly and was causing…

### DIFF
--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -138,9 +138,9 @@ namespace winsw.Util
             ps.WorkingDirectory = workingDirectory ?? ps.WorkingDirectory;
             ps.CreateNoWindow = false;
             ps.UseShellExecute = false;
-            ps.RedirectStandardInput = true; // this creates a pipe for stdin to the new process, instead of having it inherit our stdin.
-            ps.RedirectStandardOutput = true;
-            ps.RedirectStandardError = true;
+            ps.RedirectStandardInput = false; 
+            ps.RedirectStandardOutput = false;
+            ps.RedirectStandardError = false;
 
             if (envVars != null)
             {

--- a/src/Test/winswTests/Util/ProcessHelperTest.cs
+++ b/src/Test/winswTests/Util/ProcessHelperTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using winsw;
 using System.IO;
 using winsw.Util;
+using System.Collections.Generic;
 
 namespace winswTests.Util
 {
@@ -46,6 +47,36 @@ namespace winswTests.Util
             // And just ensure that the parsing logic is case-sensitive
             Assert.That(!envVars.ContainsKey("computername"), "Test error: the environment parsing logic is case-insensitive");
 
+        }
+
+        [Test]
+        public void ShouldNotHangWhenWritingLargeStringToStdOut()
+        {
+            var tmpDir = FilesystemTestHelper.CreateTmpDirectory();
+            String scriptFile = Path.Combine(tmpDir, "print_lots_to_stdout.bat");
+            var lotsOfStdOut = string.Join("", _Range(1,1000));
+            File.WriteAllText(scriptFile, string.Format("echo \"{0}\"", lotsOfStdOut));
+
+            Process proc = new Process();
+            var ps = proc.StartInfo;
+            ps.FileName = scriptFile;
+
+            ProcessHelper.StartProcessAndCallbackForExit(proc);
+            var exited = proc.WaitForExit(5000);
+            if (!exited)
+            {
+                Assert.Fail("Process " + proc + " didn't exit after 5 seconds");
+            }
+        }
+
+        private string[] _Range(int start, int limit)
+        {
+            var range = new List<string>();
+            for(var i = start; i<limit; i++)
+            {
+                range.Add(i.ToString());
+            }
+            return range.ToArray();
         }
     }
 }


### PR DESCRIPTION
… the child process to hang.


When this is merged, we should create a new task to include logging of stdout properly using the Log4Net feature that was recently completed. 