### PR TITLE
Issue #218 - ProcessHelper#StartProcessAndCallbackForExit() should redirect STDOUT/STDERR when LogHandler is defined

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -249,7 +249,7 @@ namespace winsw
             Log.Info("Starting " + _descriptor.Executable + ' ' + startarguments);
 
             LogHandler executableLogHandler = CreateExecutableLogHandler();
-            StartProcess(_process, startarguments, _descriptor.Executable, executableLogHandler);
+            StartProcess(_process, startarguments, _descriptor.Executable, executableLogHandler, true);
             ExtensionManager.FireOnProcessStarted(_process);
 
             _process.StandardInput.Close(); // nothing for you to read!
@@ -322,7 +322,7 @@ namespace winsw
                 }
 
                 // TODO: Redirect logging to Log4Net once https://github.com/kohsuke/winsw/pull/213 is integrated 
-                StartProcess(stopProcess, stoparguments, executable, null);
+                StartProcess(stopProcess, stoparguments, executable, null, false);
 
                 Log.Debug("WaitForProcessToExit " + _process.Id + "+" + stopProcess.Id);
                 WaitForProcessToExit(_process);
@@ -407,7 +407,7 @@ namespace winsw
             Advapi32.SetServiceStatus(handle, ref _wrapperServiceStatus);
         }
 
-        private void StartProcess(Process processToStart, string arguments, String executable, LogHandler logHandler)
+        private void StartProcess(Process processToStart, string arguments, String executable, LogHandler logHandler, bool redirectStdin)
         {
             
             // Define handler of the completed process
@@ -455,7 +455,8 @@ namespace winsw
                 workingDirectory: _descriptor.WorkingDirectory,
                 priority: _descriptor.Priority,
                 callback: processCompletionCallback,
-                logHandler: logHandler);
+                logHandler: logHandler,
+                redirectStdin: redirectStdin);
         }
 
         public static int Main(string[] args)

--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -129,8 +129,9 @@ namespace winsw.Util
         /// <param name="workingDirectory">Working directory</param>
         /// <param name="priority">Priority</param>
         /// <param name="callback">Completion callback. If null, the completion won't be monitored</param>
+        /// <param name="logHandler">Log handler. If enabled, logs will be redirected to the process and then reported</param>
         public static void StartProcessAndCallbackForExit(Process processToStart, String executable = null, string arguments = null, Dictionary<string, string> envVars = null,
-            string workingDirectory = null, ProcessPriorityClass? priority = null, ProcessCompletionCallback callback = null)
+            string workingDirectory = null, ProcessPriorityClass? priority = null, ProcessCompletionCallback callback = null, LogHandler logHandler = null)
         {
             var ps = processToStart.StartInfo;
             ps.FileName = executable ?? ps.FileName;
@@ -138,9 +139,9 @@ namespace winsw.Util
             ps.WorkingDirectory = workingDirectory ?? ps.WorkingDirectory;
             ps.CreateNoWindow = false;
             ps.UseShellExecute = false;
-            ps.RedirectStandardInput = false; 
-            ps.RedirectStandardOutput = false;
-            ps.RedirectStandardError = false;
+            ps.RedirectStandardInput = false;
+            ps.RedirectStandardOutput = logHandler != null;
+            ps.RedirectStandardError = logHandler != null;
 
             if (envVars != null)
             {
@@ -158,6 +159,13 @@ namespace winsw.Util
             if (priority != null && priority.Value != ProcessPriorityClass.Normal) 
             { 
                 processToStart.PriorityClass = priority.Value;
+            }
+
+            // Redirect logs if required
+            if (logHandler != null)
+            {
+                Logger.Debug("Forwarding logs of the process " + processToStart + " to " + logHandler);
+                logHandler.log(processToStart.StandardOutput.BaseStream, processToStart.StandardError.BaseStream);
             }
 
             // monitor the completion of the process

--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -130,8 +130,9 @@ namespace winsw.Util
         /// <param name="priority">Priority</param>
         /// <param name="callback">Completion callback. If null, the completion won't be monitored</param>
         /// <param name="logHandler">Log handler. If enabled, logs will be redirected to the process and then reported</param>
+        /// <param name="redirectStdin">Redirect standard input</param>
         public static void StartProcessAndCallbackForExit(Process processToStart, String executable = null, string arguments = null, Dictionary<string, string> envVars = null,
-            string workingDirectory = null, ProcessPriorityClass? priority = null, ProcessCompletionCallback callback = null, LogHandler logHandler = null)
+            string workingDirectory = null, ProcessPriorityClass? priority = null, ProcessCompletionCallback callback = null, bool redirectStdin = true, LogHandler logHandler = null)
         {
             var ps = processToStart.StartInfo;
             ps.FileName = executable ?? ps.FileName;
@@ -139,7 +140,7 @@ namespace winsw.Util
             ps.WorkingDirectory = workingDirectory ?? ps.WorkingDirectory;
             ps.CreateNoWindow = false;
             ps.UseShellExecute = false;
-            ps.RedirectStandardInput = false;
+            ps.RedirectStandardInput = redirectStdin;
             ps.RedirectStandardOutput = logHandler != null;
             ps.RedirectStandardError = logHandler != null;
 


### PR DESCRIPTION
It restores logging of executables, which has been broken in https://github.com/kohsuke/winsw/pull/220.
Not a regression, because the change has not been released yet. 

It is not a full fix, I still need to determine why it causes a preliminary service exit in the case of the infinite ping executable. 

CC @pnikonowicz 