### PR TITLE
Issue #237 - Improve diagnostics of the Runaway Process Killer when it kills the process

### DIFF
--- a/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
+++ b/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
@@ -6,6 +6,7 @@ using winsw.Extensions;
 using winsw.Util;
 using log4net;
 using System.Collections.Specialized;
+using System.Text;
 
 namespace winsw.Plugins.RunawayProcessKiller
 {
@@ -151,7 +152,16 @@ namespace winsw.Plugins.RunawayProcessKiller
             }
 
             // Kill the runaway process
-            Logger.Warn("Stopping the runaway process (pid=" + pid + ") and its children.");
+            StringBuilder bldr = new StringBuilder("Stopping the runaway process (pid=");
+            bldr.Append(pid);
+            bldr.Append(") and its children. Environment was ");
+            if (!CheckWinSWEnvironmentVariable) {
+                bldr.Append("not ");
+            }
+            bldr.Append("checked, affiliated service ID: ");
+            bldr.Append(affiliatedServiceId != null ? affiliatedServiceId : "undefined");
+
+            Logger.Warn(bldr.ToString());
             ProcessHelper.StopProcessAndChildren(pid, this.StopTimeout, this.StopParentProcessFirst);
         }
 

--- a/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
+++ b/src/Plugins/RunawayProcessKiller/RunawayProcessKillerExtension.cs
@@ -160,6 +160,8 @@ namespace winsw.Plugins.RunawayProcessKiller
             }
             bldr.Append("checked, affiliated service ID: ");
             bldr.Append(affiliatedServiceId != null ? affiliatedServiceId : "undefined");
+            bldr.Append(", process to kill: ");
+            bldr.Append(proc);
 
             Logger.Warn(bldr.ToString());
             ProcessHelper.StopProcessAndChildren(pid, this.StopTimeout, this.StopParentProcessFirst);


### PR DESCRIPTION
See #237. The change adds some extra diagnostics, which may help to determine if we kill the right process. 

For more hardening, I could also add the executable name check. After such change WinSW will ignore Runaway processes if the executable name changes. This is not a real case IMHO.

@Thomehack @reviewbybees