### PR TITLE
Add a new `hidewindow` option to suppress windows popup on legacy platforms

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -456,7 +456,8 @@ namespace winsw
                 priority: _descriptor.Priority,
                 callback: processCompletionCallback,
                 logHandler: logHandler,
-                redirectStdin: redirectStdin);
+                redirectStdin: redirectStdin,
+                hideWindow: _descriptor.HideWindow);
         }
 
         public static int Main(string[] args)

--- a/src/Core/WinSWCore/Configuration/DefaultSettings.cs
+++ b/src/Core/WinSWCore/Configuration/DefaultSettings.cs
@@ -18,6 +18,7 @@ namespace winsw.Configuration
         public string Caption { get { return null; } }
         public string Description { get { return null; } }
         public string Executable { get { return null; } }
+        public bool HideWindow { get { return false; } }
 
         public string ExecutablePath
         {

--- a/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
+++ b/src/Core/WinSWCore/Configuration/IWinSWConfiguration.cs
@@ -14,6 +14,7 @@ namespace winsw.Configuration
         string Description { get; }
         string Executable { get; }
         string ExecutablePath { get; }
+        bool HideWindow { get; }
 
         // Installation
         bool AllowServiceAcountLogonRight { get; }

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -175,6 +175,13 @@ namespace winsw
             }
         }
 
+        public bool HideWindow 
+        { 
+            get {
+                return SingleBoolElement("hidewindow", Defaults.HideWindow);
+            } 
+        }
+
         /// <summary>
         /// Optionally specify a different Path to an executable to shutdown the service.
         /// </summary>

--- a/src/Core/WinSWCore/Util/ProcessHelper.cs
+++ b/src/Core/WinSWCore/Util/ProcessHelper.cs
@@ -132,13 +132,13 @@ namespace winsw.Util
         /// <param name="logHandler">Log handler. If enabled, logs will be redirected to the process and then reported</param>
         /// <param name="redirectStdin">Redirect standard input</param>
         public static void StartProcessAndCallbackForExit(Process processToStart, String executable = null, string arguments = null, Dictionary<string, string> envVars = null,
-            string workingDirectory = null, ProcessPriorityClass? priority = null, ProcessCompletionCallback callback = null, bool redirectStdin = true, LogHandler logHandler = null)
+            string workingDirectory = null, ProcessPriorityClass? priority = null, ProcessCompletionCallback callback = null, bool redirectStdin = true, LogHandler logHandler = null, bool hideWindow = false)
         {
             var ps = processToStart.StartInfo;
             ps.FileName = executable ?? ps.FileName;
             ps.Arguments = arguments ?? ps.Arguments;
             ps.WorkingDirectory = workingDirectory ?? ps.WorkingDirectory;
-            ps.CreateNoWindow = false;
+            ps.CreateNoWindow = hideWindow;
             ps.UseShellExecute = false;
             ps.RedirectStandardInput = redirectStdin;
             ps.RedirectStandardOutput = logHandler != null;


### PR DESCRIPTION
adds a `<hidewindow>true</hidewindow>` config switch
so that launching bat files on legacy machines
running Interactive Services Detection doesn't balk with horrid warnings.
default behaviour remains as before.