### PR TITLE
Treat ERROR_SERVICE_CANNOT_ACCEPT_CTRL as success for stop command

### DIFF
--- a/src/Core/ServiceWrapper/Main.cs
+++ b/src/Core/ServiceWrapper/Main.cs
@@ -728,7 +728,22 @@ namespace winsw
                 if (s is null)
                     ThrowNoSuchService();
 
-                s.StopService();
+                try
+                {
+                    s.StopService();
+                }
+                catch (WmiException e)
+                {
+                    if (e.ErrorCode == ReturnValue.ServiceCannotAcceptControl)
+                    {
+                        Log.Info($"The service with ID '{descriptor.Id}' is not running");
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+
                 return;
             }
 


### PR DESCRIPTION
Closes #309 

The corresponding Windows API `ControlService` will return `ERROR_SERVICE_NOT_ACTIVE` instead.