### PR TITLE
Add ZipDaysToKeep to roll-by-size-time appender

### DIFF
--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="ilmerge" Version="3.0.29" />
+    <PackageReference Include="ilmerge" Version="3.0.40" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="ilmerge" Version="3.0.40" />
+    <PackageReference Include="ilmerge" Version="3.0.29" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,6 +14,12 @@
     <Copyright>Copyright 2008-2016 Oleg Nenashev, CloudBees, Inc. and other contributors</Copyright>
     <RootNamespace>winsw</RootNamespace>
     <AssemblyName>WindowsService</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <AssemblyOriginatorKeyFile>winsw_key.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <AssemblyVersion>2.9.1.0</AssemblyVersion>
+    <FileVersion>2.9.1.0</FileVersion>
+    <Version>2.9.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -17,9 +17,9 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>winsw_key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <AssemblyVersion>2.9.2.0</AssemblyVersion>
-    <FileVersion>2.9.2.0</FileVersion>
-    <Version>2.9.2</Version>
+    <AssemblyVersion>2.9.3.0</AssemblyVersion>
+    <FileVersion>2.9.3.0</FileVersion>
+    <Version>2.9.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -17,9 +17,9 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>winsw_key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <AssemblyVersion>2.9.1.0</AssemblyVersion>
-    <FileVersion>2.9.1.0</FileVersion>
-    <Version>2.9.1</Version>
+    <AssemblyVersion>2.9.2.0</AssemblyVersion>
+    <FileVersion>2.9.2.0</FileVersion>
+    <Version>2.9.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -22,10 +22,6 @@
     <Version>2.9.2</Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <ILMergeVersion>3.0.40</ILMergeVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
@@ -36,7 +32,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="ilmerge" Version="$(ILMergeVersion)" />
+    <PackageReference Include="ilmerge" Version="3.0.29" />
+    <PackageReference Include="ilmerge" Version="3.0.40" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>

--- a/src/Core/ServiceWrapper/winsw.csproj
+++ b/src/Core/ServiceWrapper/winsw.csproj
@@ -102,7 +102,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <ILMerge>$(NuGetPackageRoot)ilmerge\$(ILMergeVersion)\tools\net452\ILMerge.exe</ILMerge>
+      <ILMerge>$(NuGetPackageRoot)ilmerge\3.0.29\tools\net452\ILMerge.exe</ILMerge>
       <ILMergeArgs>/targetplatform:$(TargetPlatform) /out:$(OutputAssembly) $(InputAssemblies)</ILMergeArgs>
       <ILMergeCommand>"$(ILMerge)" $(ILMergeArgs)</ILMergeCommand>
     </PropertyGroup>

--- a/src/Core/WinSWCore/LogAppenders.cs
+++ b/src/Core/WinSWCore/LogAppenders.cs
@@ -399,7 +399,7 @@ namespace winsw
                             var nextFileName = Path.Combine(baseDirectory, string.Format("{0}.{1}.#{2:D4}{3}", baseFileName, now.ToString(FilePattern), nextFileNumber, extension));
                             File.Move(logFile, nextFileName);
 
-                            writer = CreateWriter(new FileStream(logFile, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
+                            writer = CreateWriter(new FileStream(logFile, FileMode.Create));
                             fileLength = new FileInfo(logFile).Length;
                         }
 
@@ -441,7 +441,7 @@ namespace winsw
 
                             // even if the log rotation fails, create a new one, or else
                             // we'll infinitely try to roll.
-                            writer = CreateWriter(new FileStream(logFile, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
+                            writer = CreateWriter(new FileStream(logFile, FileMode.Create));
                             fileLength = new FileInfo(logFile).Length;
                         }
                         catch (Exception e)
@@ -492,47 +492,32 @@ namespace winsw
                 try
                 {
                     //Get all the zipfiles that might match the naming pattern
-                    List<string> ZipFiles = new List<string>(Directory.GetFiles(directory, zipFileBaseName + ".*.zip"));
-                    //Now delete the ones we don't want to keep, skipping any that don't match the naming pattern
-                    foreach ( string zipFilePath in ZipFiles)
+                    //and delete the ones we don't want to keep, skipping any that don't match the naming pattern
+                    foreach ( string zipFilePath in Directory.GetFiles(directory, zipFileBaseName + ".*.zip"))
                     {
                         if (File.Exists(zipFilePath))
                         {
                             //ZipDateFormat could contain literal characters, including the '.', so this gets a bit tricky
                             string fileNameOnly = Path.GetFileNameWithoutExtension(zipFilePath);
+                            int datePartStartIndex = zipFileBaseName.Split('.').Length; //zipFileBaseName could also contain '.'
                             string[] parts = fileNameOnly.Split('.');
-                            string datePart;
-                            if(parts.Length > 2)
+                            string datePart = parts[datePartStartIndex];
+                            if (parts.Length > 2)
                             {
-                                datePart = parts[1];
-                                for(int index = 2; index < parts.Length; index++)
+                                for (int index = datePartStartIndex + 1; index < parts.Length; index++)
                                 {
                                     datePart += "." + parts[index];
                                 }
                             }
-                            else
+                            if (DateTime.TryParseExact(datePart, ZipDateFormat, System.Globalization.CultureInfo.CurrentCulture, System.Globalization.DateTimeStyles.None, out DateTime date))
                             {
-                                datePart = parts[parts.Length - 1];
-                            }
-                            //EventLogger.LogEvent($"{zipFilePath}: datePart = {datePart}");
-                            if (DateTime.TryParseExact(datePart, ZipDateFormat, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out DateTime date))
-                            {
-                                //the date portion of the name matches the configured ZipDateFormat
-                                if (date.CompareTo(DateTime.Now.AddDays((double)(-ZipDaysToKeep - ZipOlderThanNumDays))) < 0)
+                                    //the date portion of the name matches the configured ZipDateFormat
+                                    if (date < DateTime.Now.AddDays((double)(-ZipDaysToKeep - ZipOlderThanNumDays)))
                                 {
                                     //the file is older than the configured ZipDaysToKeep. Also take the configured ZipOlderThanNumDays into account as ZipDaysToKeep should only apply to zip files
-                                    //EventLogger.LogEvent($"{zipFilePath}: datePart matches format {datePart} : {ZipDateFormat}, is older than {ZipDaysToKeep + ZipOlderThanNumDays} days, deleting ");
                                     File.Delete(zipFilePath);
                                 }
-                                //else
-                                //{
-                                //    EventLogger.LogEvent($"{zipFilePath}: datePart matches format {datePart} : {ZipDateFormat}, is younger than {ZipDaysToKeep + ZipOlderThanNumDays} days, not deleting ");
-                                //}
                             }
-                            //else
-                            //{
-                            //    EventLogger.LogEvent($"datePart does not match format {datePart} : {ZipDateFormat}, not deleting {zipFilePath}");
-                            //}
                         }
                     }
                 } catch (Exception e)
@@ -577,13 +562,11 @@ namespace winsw
                 if (File.Exists(zipFilePath))
                 {
                     zipFile = new ZipFile(File.Open(zipFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite));
-                    //zipFile = new ZipFile(zipFilePath);
                 }
                 else
                 {
                     
                     zipFile = ZipFile.Create(File.Open(zipFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite));
-                    //zipFile = ZipFile.Create(zipFilePath);
                 }
 
                 zipFile.BeginUpdate();
@@ -644,7 +627,6 @@ namespace winsw
                         var filenameOnly = Path.GetFileNameWithoutExtension(f);
                         var hashIndex = filenameOnly.IndexOf('#');
                         var lastNumberAsString = filenameOnly.Substring(hashIndex + 1, 4);
-                        // var lastNumberAsString = filenameOnly.Substring(filenameOnly.Length - 4, 4);
                         if (int.TryParse(lastNumberAsString, out int lastNumber))
                         {
                             if (lastNumber > nextFileNumber)

--- a/src/Core/WinSWCore/ServiceDescriptor.cs
+++ b/src/Core/WinSWCore/ServiceDescriptor.cs
@@ -467,7 +467,18 @@ namespace winsw
                         XmlNode? zipdateformatNode = e.SelectSingleNode("zipDateFormat");
                         string zipdateformat = zipdateformatNode is null ? "yyyyMM" : zipdateformatNode.InnerText;
 
-                        return new RollingSizeTimeLogAppender(LogDirectory, LogName, OutFileDisabled, ErrFileDisabled, OutFilePattern, ErrFilePattern, sizeThreshold, filePatternNode.InnerText, autoRollAtTime, zipolderthannumdays, zipdateformat);
+                        XmlNode? zipdaystokeepNode = e.SelectSingleNode("zipDaysToKeep");
+                        int? zipdaystokeep = null;
+                        if (zipdaystokeepNode != null)
+                        {
+                            // validate it
+                            if (!int.TryParse(zipdaystokeepNode.InnerText, out int zipdaystokeepValue))
+                                throw new InvalidDataException("Roll-Size-Time Based rolling policy is specified but zipDaysToKeep does not match the int format found in configuration XML.");
+
+                            zipdaystokeep = zipdaystokeepValue;
+                        }
+
+                        return new RollingSizeTimeLogAppender(LogDirectory, LogName, OutFileDisabled, ErrFileDisabled, OutFilePattern, ErrFilePattern, sizeThreshold, filePatternNode.InnerText, autoRollAtTime, zipolderthannumdays, zipdateformat, zipdaystokeep);
 
                     default:
                         throw new InvalidDataException("Undefined logging mode: " + LogMode);

--- a/src/Core/WinSWCore/WinSWCore.csproj
+++ b/src/Core/WinSWCore/WinSWCore.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'net40'">
-    <PackageReference Include="SharpZipLib" Version="0.86.0" />
+    <PackageReference Include="SharpZipLib" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/WinSWCore/WinSWCore.csproj
+++ b/src/Core/WinSWCore/WinSWCore.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'net40'">
-    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+    <PackageReference Include="SharpZipLib" Version="0.86.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/WinSWCore/WinSWCore.csproj
+++ b/src/Core/WinSWCore/WinSWCore.csproj
@@ -14,6 +14,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="System.Collections">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <PackageReference Include="System.Diagnostics.EventLog" Version="4.7.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
@@ -35,6 +38,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="System.Collections">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
 

--- a/src/Test/winswTests/winswTests.csproj
+++ b/src/Test/winswTests/winswTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.0">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Test/winswTests/winswTests.csproj
+++ b/src/Test/winswTests/winswTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="1.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Implemented a new option on the `RollingSizeTimeLogAppender `that allows configuration of a number of days for which zipped log files should be kept.

Fixed issues with log archiving in RollingSizeTimeAppender.
