### PR TITLE
Fixed bug constructing command-line for elevated process in .NET 5

### DIFF
--- a/src/WinSW/Program.cs
+++ b/src/WinSW/Program.cs
@@ -601,19 +601,15 @@ namespace WinSW
                 string? stderrName = Console.IsErrorRedirected ? Guid.NewGuid().ToString() : null;
 #endif
 
-                string arguments = "/elevated " +
+                string exe = Environment.GetCommandLineArgs()[0];
+                string commandLine = Environment.CommandLine;
+                string arguments = "/elevated" +
 #if VNEXT
                     " " + (stdinName ?? NoPipe) +
                     " " + (stdoutName ?? NoPipe) +
                     " " + (stderrName ?? NoPipe) +
 #endif
-#if NET
-                    string.Join(' ', args);
-#elif !NET20
-                    string.Join(" ", args);
-#else
-                    string.Join(" ", args.ToArray());
-#endif
+                    commandLine.Remove(commandLine.IndexOf(exe), exe.Length).TrimStart('"');
 
                 var startInfo = new ProcessStartInfo
                 {


### PR DESCRIPTION
When elevating with .NET 5.0, the constructed command-line is incorrect, due to spacing.  For example, when elevating the `start` command, we get:

```
WinSW.exe /elevated  - - -start
```

when what we actually want is

```
WinSW.exe /elevated - - - start
```