### PR TITLE
fix unhandled exception when signaling service stoped

### DIFF
--- a/src/WinSW/WrapperService.cs
+++ b/src/WinSW/WrapperService.cs
@@ -391,10 +391,14 @@ namespace WinSW
 
         private void SignalStopped()
         {
-            using var scm = ServiceManager.Open();
-            using var sc = scm.OpenService(this.ServiceName, ServiceApis.ServiceAccess.QueryStatus);
+            try {
+                using var scm = ServiceManager.Open();
+                using var sc = scm.OpenService(this.ServiceName, ServiceApis.ServiceAccess.QueryStatus);
 
-            sc.SetStatus(this.ServiceHandle, ServiceControllerStatus.Stopped);
+                sc.SetStatus(this.ServiceHandle, ServiceControllerStatus.Stopped);
+            } catch (Exception e) {
+                Log.Error("Failed to signal service stopped status", e);
+            }
         }
 
         private void StartProcess(Process processToStart, string arguments, string executable, LogHandler? logHandler)


### PR DESCRIPTION
should fix the error occured in
- #980

So the process can properly exit
https://github.com/winsw/winsw/blob/6cf303c1d3fbe1069d95af230b8efa117d29cdf2/src/WinSW/WrapperService.cs#L419-L424