### PR TITLE
feat: Create directory hierarchy if not exists

### DIFF
--- a/src/WinSW.Core/Util/FileHelper.cs
+++ b/src/WinSW.Core/Util/FileHelper.cs
@@ -12,6 +12,7 @@ namespace WinSW.Util
     {
         public static void MoveOrReplaceFile(string sourceFileName, string destFileName)
         {
+            new FileInfo(destFileName).Directory?.Create();
 #if NET
             File.Move(sourceFileName, destFileName, true);
 #else


### PR DESCRIPTION
When using the deferred file operations as a means of driving an update feature.  I realized that only files in folders that exist will be written.  If the folder hierarchy does not exist, then the file will not be written:

This mitigates the issue by ensuring the directory has been created before attempting to move or replace the file