### PR TITLE
fix: overwrite if file already exists

### DIFF
--- a/src/WinSW.Core/LogAppenders.cs
+++ b/src/WinSW.Core/LogAppenders.cs
@@ -315,18 +315,14 @@ namespace WinSW
                         {
                             string dst = this.BaseLogFileName + "." + (j - 1) + ext;
                             string src = this.BaseLogFileName + "." + (j - 2) + ext;
-                            if (File.Exists(dst))
-                            {
-                                File.Delete(dst);
-                            }
 
                             if (File.Exists(src))
                             {
-                                File.Move(src, dst);
+                                File.Move(src, dst, true);
                             }
                         }
 
-                        File.Move(this.BaseLogFileName + ext, this.BaseLogFileName + ".0" + ext);
+                        File.Move(this.BaseLogFileName + ext, this.BaseLogFileName + ".0" + ext, true);
                     }
                     catch (IOException e)
                     {


### PR DESCRIPTION
Considering the case of a single keepFile (keepFile setting with value 0 or 1), it should overwrite any existing file.
This way you will always have the most recent file saved as keepfile.