### PR TITLE
Document `hidewindow` configuration

### DIFF
--- a/docs/xml-config-file.md
+++ b/docs/xml-config-file.md
@@ -219,6 +219,17 @@ This optional element can be specified multiple times if necessary to specify en
 <env name="HOME" value="c:\abc" />
 ```
 
+### hidewindow
+
+**Optional**
+When set to `true`, WinSW starts the service process with `CreateNoWindow=true`, which prevents a console window from being created.
+This is mainly useful for console applications and for avoiding a briefly visible window during startup.
+The default value is `false`.
+
+```xml
+<hidewindow>true</hidewindow>
+```
+
 ### interactive
 
 If this optional element is specified, the service will be allowed to interact with the desktop, such as by showing a new window and dialog boxes.

--- a/samples/complete.xml
+++ b/samples/complete.xml
@@ -130,6 +130,15 @@ SECTION: Executable management
 -->
 
   <!--
+    OPTION: hidewindow
+    When true, starts the executable with CreateNoWindow=true (no console window).
+    Default value: false
+  -->
+  <!--
+  <hidewindow>true</hidewindow>
+  -->
+
+  <!--
     OPTION: priority
     Desired process priority.
     Possible values: Normal, Idle, High, RealTime, BelowNormal, AboveNormal


### PR DESCRIPTION
Addresses #657 by documenting the `<hidewindow>` configuration entry.

Changes:
- Add a new `hidewindow` section to `docs/xml-config-file.md` describing its behavior (`CreateNoWindow=true`) and default.
- Add a commented example to `samples/complete.xml`.

Note: I didn't find YAML config docs/schema on the `v3` branch; if there is a canonical location for YAML configuration, I can follow up and add the same description there.
