### PR TITLE
fix: allow net7 build to run on newer .NET runtimes

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -42,6 +42,8 @@ steps:
     command: test
     projects: src\WinSW.Tests\WinSW.Tests.csproj
     arguments: -c $(BuildConfiguration) --collect "XPlat Code Coverage" --no-build
+  env:
+    DOTNET_ROLL_FORWARD: Major
 - task: NuGetToolInstaller@1
   displayName: Install NuGet
   inputs:

--- a/src/WinSW.Core/SharedDirectoryMapper.cs
+++ b/src/WinSW.Core/SharedDirectoryMapper.cs
@@ -18,7 +18,7 @@ namespace WinSW
             foreach (var config in this.entries)
             {
                 string label = config.Label;
-                string uncPath = config.UncPath;
+                string uncPath = config.UncPath.TrimEnd('\\', '/');
 
                 int error = WNetAddConnection2W(new()
                 {

--- a/src/WinSW.Tests/CommandLineTests.cs
+++ b/src/WinSW.Tests/CommandLineTests.cs
@@ -19,8 +19,8 @@ namespace WinSW.Tests
             {
                 _ = Helper.Test(new[] { "install", config.FullPath }, config);
 
-                using var controller = new ServiceController(Helper.Name);
-                Assert.Equal(Helper.DisplayName, controller.DisplayName);
+                using var controller = new ServiceController(config.Name);
+                Assert.Equal(config.DisplayName, controller.DisplayName);
                 Assert.False(controller.CanStop);
                 Assert.False(controller.CanShutdown);
                 Assert.False(controller.CanPauseAndContinue);
@@ -44,7 +44,7 @@ namespace WinSW.Tests
 
                         if (Environment.GetEnvironmentVariable("System.DefinitionId") != null)
                         {
-                            session = new InterProcessCodeCoverageSession(Helper.Name);
+                            session = new InterProcessCodeCoverageSession(config.Name);
                         }
                     }
                     finally

--- a/src/WinSW.Tests/SharedDirectoryMapperTests.cs
+++ b/src/WinSW.Tests/SharedDirectoryMapperTests.cs
@@ -32,16 +32,23 @@ namespace WinSW.Tests.Extensions
         }
 
         [ElevatedFact]
-        public void TestMap_PathEndsWithSlash_Throws()
+        public void TestMap_PathEndsWithSlash()
         {
             using var data = TestData.Create();
 
             const string label = "W:";
             var mapper = CreateMapper(label, $@"\\{Environment.MachineName}\{data.name}\");
 
-            _ = Assert.ThrowsAny<Exception>(() => mapper.Map());
+            mapper.Map();
+            try
+            {
+                Assert.True(Directory.Exists($@"{label}\"));
+            }
+            finally
+            {
+                mapper.Unmap();
+            }
             Assert.False(Directory.Exists($@"{label}\"));
-            _ = Assert.ThrowsAny<Exception>(() => mapper.Unmap());
         }
 
         [ElevatedFact]

--- a/src/WinSW.Tests/Util/CommandLineTestHelper.cs
+++ b/src/WinSW.Tests/Util/CommandLineTestHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Xml;
 using Xunit;
 
@@ -113,7 +115,7 @@ $@"<service>
                     string path = this.FullPath = Path.Combine(directory, "config.xml");
                     using (var file = File.CreateText(path))
                     {
-                        file.Write(SeedXml);
+                        file.Write(this.dom.OuterXml);
                     }
 
                     this.BaseName = name;
@@ -140,7 +142,31 @@ $@"<service>
             {
                 var document = new XmlDocument();
                 document.LoadXml(xml);
-                return new TestXmlServiceConfig(document, name);
+
+                string suffix = Guid.NewGuid().ToString("N").Substring(0, 8);
+                string serviceId = $"{CommandLineTestHelper.Name}-{suffix}";
+
+                var serviceNode = document.SelectSingleNode("/service");
+                if (serviceNode is null)
+                {
+                    throw new InvalidDataException("<service> is missing in configuration XML");
+                }
+
+                var idNode = serviceNode.SelectSingleNode("id");
+                if (idNode is null)
+                {
+                    idNode = document.CreateElement("id");
+                    _ = serviceNode.PrependChild(idNode);
+                }
+                idNode.InnerText = serviceId;
+
+                var displayNameNode = serviceNode.SelectSingleNode("name");
+                if (displayNameNode is not null)
+                {
+                    displayNameNode.InnerText = $"{CommandLineTestHelper.DisplayName} ({suffix})";
+                }
+
+                return new TestXmlServiceConfig(document, $"{name}-{suffix}");
             }
 
             public void Dispose()
@@ -153,8 +179,25 @@ $@"<service>
             {
                 if (!disposed)
                 {
-                    Directory.Delete(this.directory, true);
                     disposed = true;
+                    DeleteDirectoryWithRetry(this.directory, TimeSpan.FromSeconds(5));
+                }
+            }
+
+            private static void DeleteDirectoryWithRetry(string directory, TimeSpan timeout)
+            {
+                var start = Stopwatch.StartNew();
+                while (true)
+                {
+                    try
+                    {
+                        Directory.Delete(directory, true);
+                        return;
+                    }
+                    catch (Exception) when (start.Elapsed < timeout)
+                    {
+                        Thread.Sleep(200);
+                    }
                 }
             }
         }

--- a/src/WinSW/WinSW.csproj
+++ b/src/WinSW/WinSW.csproj
@@ -26,6 +26,10 @@
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0-windows'">
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' != 'net7.0-windows'">
     <ILMergeVersion>3.0.41</ILMergeVersion>
   </PropertyGroup>


### PR DESCRIPTION
Azure windows-latest hosted agents no longer include a .NET 7 runtime by default (only 8.x/9.x/10.x), which breaks running the net7.0-windows testhost and starting the net7 WinSW apphost as a service (required Microsoft.NETCore.App 7.0.0).

This PR restores CI by:
- setting <RollForward>Major</RollForward> for the net7.0-windows WinSW build so it can run on newer installed runtimes
- setting DOTNET_ROLL_FORWARD=Major for the Test step (eng/build.yml) so net7 tests can run on the installed 8.x runtime
- making elevated service integration tests use a unique service id/temp folder per run to avoid collisions between net471 and net7 runs

Found while working on #1122.