### PR TITLE
Fix Shared Directory Mapper link

### DIFF
--- a/docs/extensions/extensions.md
+++ b/docs/extensions/extensions.md
@@ -5,7 +5,7 @@ These extensions allow to alter the behavior of the Windows service in order to 
 
 ## Available extensions
 
-* [Shared Directory Mapper](shared-directory-mapper.md) - Allows mapping shared drives before starting the executable
+* [Shared Directory Mapper](../xml-config-file.md#shareddirectorymapping) - Allows mapping shared drives before starting the executable
 
 ## Developer guide
 


### PR DESCRIPTION
Fixes #849.

`docs/extensions/extensions.md` linked to `shared-directory-mapper.md` (non-existent). This updates the link to the existing `sharedDirectoryMapping` section in `docs/xml-config-file.md`.