### PR TITLE
docs: update contributing prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 ## Prerequisites
 
-[.NET 5 SDK or later](https://dotnet.microsoft.com/download/dotnet/5.0) and your favorite code editor.
+[.NET SDK (7.0 or later)](https://dotnet.microsoft.com/download) and your favorite code editor.
 
-- [Visual Studio 2019 or later](https://visualstudio.microsoft.com/downloads/) with the **.NET desktop development** workload
+- [Visual Studio 2022 or later](https://visualstudio.microsoft.com/downloads/) with the **.NET desktop development** workload
 - [Visual Studio Code](https://code.visualstudio.com/Download) with the [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension
 
 ## Develop in Visual Studio
@@ -27,4 +27,4 @@ dotnet test src\WinSW.sln
 
 ## See also
 
-[How to: Debug Windows Service Applications](https://docs.microsoft.com/dotnet/framework/windows-services/how-to-debug-windows-service-applications)
+[How to: Debug Windows Service Applications](https://learn.microsoft.com/dotnet/framework/windows-services/how-to-debug-windows-service-applications)


### PR DESCRIPTION
This updates `CONTRIBUTING.md` prerequisites to match the current target frameworks (e.g. `net7.0-windows`).

- Require .NET SDK 7.0+ (instead of .NET 5)
- Require Visual Studio 2022+ (instead of VS 2019)
- Update a Microsoft Docs link to `learn.microsoft.com`

Docs-only change.