### PR TITLE
WrapperService: open SCM with Connect in SignalStopped

### DIFF
--- a/src/WinSW.Core/WrapperService.cs
+++ b/src/WinSW.Core/WrapperService.cs
@@ -489,7 +489,7 @@ namespace WinSW
 
         private void SignalStopped()
         {
-            using var scm = ServiceManager.Open();
+            using var scm = ServiceManager.Open(ServiceApis.ServiceManagerAccess.Connect);
             using var sc = scm.OpenService(this.ServiceName, ServiceApis.ServiceAccess.QueryStatus);
 
             sc.SetStatus(this.ServiceHandle, ServiceControllerStatus.Stopped);


### PR DESCRIPTION
Refs #1136

### Context
Issue #1136 reports an `Access is denied` error when WinSW tries to report a clean child-process exit (`ExitCode == 0`) via `WrapperService.SignalStopped()` while running under a restricted service account.

`SignalStopped()` currently calls `ServiceManager.Open()` (defaults to `ServiceManagerAccess.All`), which can require elevated SCM permissions.

### Change
- Open the SCM with `ServiceManagerAccess.Connect` in `SignalStopped()`.

### Validation
- `dotnet build src/WinSW.Core/WinSW.Core.csproj -c Release`

### Notes
- This is a minimal change on the `v3` branch; if you want a `v2` backport as well, I can prepare it.
