### PR TITLE
docs: clarify branch/release status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@
 
 WinSW wraps and manages any application as a Windows service.
 
-**We are actively developing WinSW 3. Please refer to the [v2](https://github.com/winsw/winsw/tree/master) branch for previous version documentation.**
+## Project status
+
+- Development of WinSW 3.x happens on the default branch [`v3`](https://github.com/winsw/winsw/tree/v3).
+- GitHub Releases contains stable 2.x releases and 3.x pre-releases. NuGet and Maven packages currently correspond to 2.x.
+- For WinSW 2.x documentation, refer to the [`master`](https://github.com/winsw/winsw/tree/master) branch.
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ WinSW wraps and manages any application as a Windows service.
 
 - Development of WinSW 3.x happens on the default branch [`v3`](https://github.com/winsw/winsw/tree/v3).
 - GitHub Releases contains stable 2.x releases and 3.x pre-releases. NuGet and Maven packages currently correspond to 2.x.
-- For WinSW 2.x documentation, refer to the [`master`](https://github.com/winsw/winsw/tree/master) branch.
+- For WinSW 2.x documentation, refer to the [`v2`](https://github.com/winsw/winsw/tree/v2) branch.
 
 ## Why?
 


### PR DESCRIPTION
Refs #1102

### Context
Some users interpret the lack of recent releases as “deprecated”, while active development happens on the `v3` branch and WinSW 2.x documentation lives on `master`.

### Change
- Add a short **Project status** section to `README.md` describing:
  - `v3` as the development/default branch
  - stable 2.x releases vs 3.x pre-releases on GitHub Releases
  - where to find 2.x documentation (`master`)

### Validation
- Docs-only change.
