### PR TITLE
WrapperService: open SCM with Connect in SignalStopped (v2 backport)

### DIFF
--- a/src/WinSW/WrapperService.cs
+++ b/src/WinSW/WrapperService.cs
@@ -391,7 +391,7 @@ namespace WinSW
 
         private void SignalStopped()
         {
-            using var scm = ServiceManager.Open();
+            using var scm = ServiceManager.Open(ServiceApis.ServiceManagerAccess.Connect);
             using var sc = scm.OpenService(this.ServiceName, ServiceApis.ServiceAccess.QueryStatus);
 
             sc.SetStatus(this.ServiceHandle, ServiceControllerStatus.Stopped);


### PR DESCRIPTION
Refs #1136

### Context
Issue #1136 reports `Access is denied` when WinSW tries to report a clean child-process exit (`ExitCode == 0`) via `WrapperService.SignalStopped()` while running under a restricted service account.

`SignalStopped()` currently calls `ServiceManager.Open()` (defaults to `ServiceManagerAccess.All`), which can require elevated SCM permissions.

### Change
- Open the SCM with `ServiceManagerAccess.Connect` in `SignalStopped()`.

### Validation
- `dotnet build src/WinSW/WinSW.csproj -c Release -f net7.0-windows -p:PublishTrimmed=false -p:NuGetAudit=false`
