### PR TITLE
CI: enable Azure Pipelines for v2

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -3,10 +3,10 @@
 name: $(Major).$(Minor).$(Patch).$(Revision)
 
 trigger:
-- master
+- v2
 
 pr:
-- master
+- v2
 
 variables:
 - group: Version

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -38,6 +38,8 @@ steps:
   displayName: Build
 - script: dotnet test -c $(BuildConfiguration) --collect "XPlat Code Coverage" --no-build src\WinSW.Tests\WinSW.Tests.csproj
   displayName: Test
+  env:
+    DOTNET_ROLL_FORWARD: Major
 - task: NuGetToolInstaller@1
   displayName: Install NuGet
   inputs:

--- a/src/WinSW.Core/WinSW.Core.csproj
+++ b/src/WinSW.Core/WinSW.Core.csproj
@@ -9,6 +9,10 @@
     <RootNamespace>WinSW</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'net40'">
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU1903</WarningsNotAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/src/WinSW.Core/WinSW.Core.csproj
+++ b/src/WinSW.Core/WinSW.Core.csproj
@@ -9,10 +9,6 @@
     <RootNamespace>WinSW</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'net40'">
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU1903</WarningsNotAsErrors>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
@@ -42,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'net40'">
-    <PackageReference Include="SharpZipLib" Version="0.86.0" />
+    <PackageReference Include="SharpZipLib" Version="0.86.0" NoWarn="NU1902;NU1903" />
   </ItemGroup>
 
 </Project>

--- a/src/WinSW.Plugins/SharedDirectoryMapperConfig.cs
+++ b/src/WinSW.Plugins/SharedDirectoryMapperConfig.cs
@@ -19,7 +19,7 @@ namespace WinSW.Plugins
         {
             this.EnableMapping = enableMapping;
             this.Label = label;
-            this.UNCPath = uncPath;
+            this.UNCPath = uncPath?.TrimEnd('\\', '/');
         }
 
         public static SharedDirectoryMapperConfig FromXml(XmlElement node)

--- a/src/WinSW.Plugins/SharedDirectoryMapperConfig.cs
+++ b/src/WinSW.Plugins/SharedDirectoryMapperConfig.cs
@@ -19,7 +19,12 @@ namespace WinSW.Plugins
         {
             this.EnableMapping = enableMapping;
             this.Label = label;
-            this.UNCPath = uncPath?.TrimEnd('\\', '/');
+            if (uncPath is null)
+            {
+                throw new ArgumentNullException(nameof(uncPath));
+            }
+
+            this.UNCPath = uncPath.TrimEnd('\\', '/');
         }
 
         public static SharedDirectoryMapperConfig FromXml(XmlElement node)

--- a/src/WinSW.Tests/Extensions/SharedDirectoryMapperTests.cs
+++ b/src/WinSW.Tests/Extensions/SharedDirectoryMapperTests.cs
@@ -40,16 +40,17 @@ namespace winswTests.Extensions
         }
 
         [Test]
-        public void TestMap_PathEndsWithSlash_Throws()
+        public void TestMap_PathEndsWithSlash_Works()
         {
             using var data = TestData.Create();
 
             const string label = "W:";
             var mapper = new SharedDirectoryMapper(true, $@"\\{Environment.MachineName}\{data.name}\", label);
 
-            Assert.That(() => mapper.OnWrapperStarted(), Throws.Exception);
+            mapper.OnWrapperStarted();
+            Assert.That($@"{label}\", Does.Exist);
+            mapper.BeforeWrapperStopped();
             Assert.That($@"{label}\", Does.Not.Exist);
-            Assert.That(() => mapper.BeforeWrapperStopped(), Throws.Exception);
         }
 
         [Test]

--- a/src/WinSW/WinSW.csproj
+++ b/src/WinSW/WinSW.csproj
@@ -14,7 +14,7 @@
     <Copyright>Copyright (c) 2008-2020 Kohsuke Kawaguchi, Sun Microsystems, Inc., CloudBees, Inc., Oleg Nenashev and other contributors</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0-windows'">
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>partial</TrimMode>
     <DebuggerSupport>false</DebuggerSupport>


### PR DESCRIPTION
### Motivation
PRs targeting `v2` currently don’t get the same Azure Pipelines coverage as `v3` because `eng/build.yml` still filters on `master`, so the pipeline is skipped/neutral for `v2` PRs.

This came up while reviewing the `v2` backport PR (#1144) where the CI signal was notably weaker than on `v3`.

Once the pipeline is enabled for `v2`, the current hosted-agent environment also exposes a few build/test blockers that prevent the pipeline from completing.

### Changes
- **Azure Pipelines triggers (v2):** update `eng/build.yml` branch filters from `master` → `v2` for both `trigger` and `pr`.
- **Test runtime on hosted agents:** set `DOTNET_ROLL_FORWARD=Major` for `dotnet test` so net7 tests can run on agents that only have newer runtimes installed.
- **Build compatibility (net20):** make trimming settings (`PublishTrimmed`, etc.) apply only to `net7.0-windows` to avoid `NETSDK1124` when building `net20` with newer SDKs.
- **NuGet audit warnings (SharpZipLib on net20/net40):** suppress `NU1902/NU1903` for the legacy `SharpZipLib 0.86.0` reference used on `net20/net40` so restore doesn’t fail under `TreatWarningsAsErrors`.
- **SharedDirectoryMapper UNC normalization:** trim trailing `\`/`/` from UNC paths and update the corresponding test to ensure `\server\share\` works consistently.

### Validation
- Azure Pipelines (Debug/Release matrix) is green on this PR.

### Notes
- The `NU1902/NU1903` suppression is scoped to the `SharpZipLib` reference that’s required for `net20/net40`. If the project decides to drop net2/net4 artifacts later, we can revisit this and remove the suppression by upgrading the dependency.