### PR TITLE
Docs: fix SharedDirectoryMapper YAML sample

### DIFF
--- a/doc/extensions/sharedDirectoryMapper.md
+++ b/doc/extensions/sharedDirectoryMapper.md
@@ -51,11 +51,11 @@ extensions:
       settings:
           mapping:
               - enabled: false
-                label: N
-                uncpath: \\UNC
+                label: N:
+                uncPath: \\UNC
               - enabled: false
-                label: M
-                uncpath: \\UNC2
+                label: M:
+                uncPath: \\UNC2
 ```
 
 ## Notes


### PR DESCRIPTION
### Motivation
The YAML example in `doc/extensions/sharedDirectoryMapper.md` currently uses:
- `label: N` / `label: M` (missing the trailing `:`)
- `uncpath` (lowercase)

But the implementation expects:
- drive labels like `N:` / `M:`
- the YAML key `uncPath` (capital `P`)

This mismatch can lead to confusing runtime failures for users who copy/paste the sample.

### Change
- Fix the YAML sample to use `label: N:` / `label: M:` and `uncPath`.

### Validation
- Doc-only change.
