### PR TITLE
SharedDirectoryMapper: make YAML parsing more tolerant

### DIFF
--- a/src/WinSW.Plugins/SharedDirectoryMapperConfig.cs
+++ b/src/WinSW.Plugins/SharedDirectoryMapperConfig.cs
@@ -40,16 +40,82 @@ namespace WinSW.Plugins
             if (yamlObject is not Dictionary<object, object> dict)
             {
                 // TODO : throw ExtensionExeption
-                throw new InvalidDataException("SharedDirectoryMapperConfig config error");
+                throw new InvalidDataException("SharedDirectoryMapperConfig mapping entry should be a dictionary");
             }
 
-            string enableMappingConfig = Environment.ExpandEnvironmentVariables((string)dict["enabled"]);
+            string enableMappingConfig = GetRequiredYamlString(dict, "enabled");
             bool enableMapping = ConfigHelper.YamlBoolParse(enableMappingConfig);
 
-            string label = Environment.ExpandEnvironmentVariables((string)dict["label"]);
-            string uncPath = Environment.ExpandEnvironmentVariables((string)dict["uncPath"]);
+            string label = NormalizeDriveLabel(GetRequiredYamlString(dict, "label"));
+            string uncPath = GetRequiredYamlString(dict, "uncPath");
 
             return new SharedDirectoryMapperConfig(enableMapping, label, uncPath);
+        }
+
+        private static string NormalizeDriveLabel(string label)
+        {
+            label = label.Trim();
+            if (label.Length == 1 && char.IsLetter(label[0]))
+            {
+                return label + ":";
+            }
+
+            return label;
+        }
+
+        private static string GetRequiredYamlString(Dictionary<object, object> dict, string key)
+        {
+            if (!TryGetYamlValue(dict, key, out object? rawValue))
+            {
+                throw new InvalidDataException($"SharedDirectoryMapperConfig mapping entry is missing '{key}'");
+            }
+
+            if (rawValue is null)
+            {
+                throw new InvalidDataException($"SharedDirectoryMapperConfig mapping entry key '{key}' cannot be null");
+            }
+
+            string? rawString = rawValue as string ?? rawValue.ToString();
+            if (rawString is null)
+            {
+                throw new InvalidDataException($"SharedDirectoryMapperConfig mapping entry key '{key}' must be a scalar value");
+            }
+
+            return Environment.ExpandEnvironmentVariables(rawString);
+        }
+
+        private static bool TryGetYamlValue(Dictionary<object, object> dict, string key, out object? value)
+        {
+            if (dict.TryGetValue(key, out value))
+            {
+                return true;
+            }
+
+            bool found = false;
+            object? foundValue = null;
+            foreach (var entry in dict)
+            {
+                if (entry.Key is not string stringKey)
+                {
+                    continue;
+                }
+
+                if (!string.Equals(stringKey, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (found)
+                {
+                    throw new InvalidDataException($"SharedDirectoryMapperConfig mapping entry contains multiple '{key}' keys");
+                }
+
+                found = true;
+                foundValue = entry.Value;
+            }
+
+            value = foundValue;
+            return found;
         }
     }
 }

--- a/src/WinSW.Tests/Extensions/SharedDirectoryMapperConfigTest.cs
+++ b/src/WinSW.Tests/Extensions/SharedDirectoryMapperConfigTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Collections.Generic;
+using NUnit.Framework;
 using WinSW;
 using WinSW.Configuration;
 using WinSW.Extensions;
@@ -104,6 +105,40 @@ extensions:
             manager.LoadExtensions();
             manager.FireOnWrapperStarted();
             manager.FireBeforeWrapperStopped();
+        }
+
+        [Test]
+        public void FromYaml_LabelWithoutColon_IsNormalized()
+        {
+            var map = new Dictionary<object, object>
+            {
+                ["enabled"] = true,
+                ["label"] = "N",
+                ["uncpath"] = @"\\UNC\Share\\",
+            };
+
+            var config = SharedDirectoryMapperConfig.FromYaml(map);
+
+            Assert.That(config.EnableMapping, Is.True);
+            Assert.That(config.Label, Is.EqualTo("N:"));
+            Assert.That(config.UNCPath, Is.EqualTo(@"\\UNC\Share"));
+        }
+
+        [Test]
+        public void FromYaml_KeysAreCaseInsensitive()
+        {
+            var map = new Dictionary<object, object>
+            {
+                ["Enabled"] = "yes",
+                ["Label"] = "m:",
+                ["UNCPath"] = @"\\UNC2\Share2",
+            };
+
+            var config = SharedDirectoryMapperConfig.FromYaml(map);
+
+            Assert.That(config.EnableMapping, Is.True);
+            Assert.That(config.Label, Is.EqualTo("m:"));
+            Assert.That(config.UNCPath, Is.EqualTo(@"\\UNC2\Share2"));
         }
     }
 }


### PR DESCRIPTION
## Motivation
When configuring `SharedDirectoryMapper` via YAML, it’s easy to run into runtime/config errors due to:

- key casing differences (`uncpath` vs `uncPath`) because YAML settings are deserialized into `Dictionary<object, object>` and accessed case-sensitively
- drive labels missing the trailing `:` (e.g. `label: N`), which then fail when passed to `WNetAddConnection2`
- non-string scalar values (e.g. YAML booleans) causing invalid casts

## Changes
- Make `SharedDirectoryMapperConfig.FromYaml(...)` resolve required keys (`enabled`, `label`, `uncPath`) case-insensitively.
- Accept non-string scalar values by converting via `ToString()`.
- Normalize single-letter drive labels (`N` -> `N:`).
- Add unit tests covering the above YAML behaviors.

## Testing
- `dotnet test src/WinSW.Tests/WinSW.Tests.csproj -c Release -f net7.0-windows --filter FullyQualifiedName~winswTests.Extensions.SharedDirectoryMapperConfigTest`