### PR TITLE
Docs: fix YAML logPath key casing

### DIFF
--- a/doc/yamlConfigFile.md
+++ b/doc/yamlConfigFile.md
@@ -96,14 +96,14 @@ depend:
 
 ### log
 
-Optionally set a different logging directory with `logpath` and startup `mode`: append (default), reset (clear log), ignore, roll (move to `\*.old`).
+Optionally set a different logging directory with `logPath` and startup `mode`: append (default), reset (clear log), ignore, roll (move to `\*.old`).
 
 User can specify all log configurations as a single YAML dictionary
 
 ```yaml
 log:
     mode: roll-by-size
-    logpath: '%BASE%\log'
+    logPath: '%BASE%\log'
     sizeThreshold: 10240
     keepFiles: 8
 ```

--- a/examples/sample-allOption.yml
+++ b/examples/sample-allOption.yml
@@ -38,7 +38,7 @@ waitHint: 15 sec
 sleepTime: 1 sec
 #interactive: true
 log:
-#    logpath: '%BASE%\logs'
+#    logPath: '%BASE%\logs'
     mode: append
 #env:
 #    -

--- a/src/WinSW.Tests/ServiceDescriptorYamlTest.cs
+++ b/src/WinSW.Tests/ServiceDescriptorYamlTest.cs
@@ -29,7 +29,7 @@ executable: node.exe
 arguments: My Arguments
 log:
     mode: roll
-    logpath: c:\logs
+    logPath: c:\logs
 serviceAccount:
     domain: {Domain}
     user: {Username}
@@ -80,6 +80,12 @@ startMode: manual";
         public void VerifyWorkingDirectory()
         {
             Assert.That(this._extendedServiceDescriptor.WorkingDirectory, Is.EqualTo(ExpectedWorkingDirectory));
+        }
+
+        [Test]
+        public void VerifyLogDirectory()
+        {
+            Assert.That(this._extendedServiceDescriptor.Log.Directory, Is.EqualTo(@"c:\logs"));
         }
 
         [Test]
@@ -265,12 +271,14 @@ name: Service
 description: The Service.
 executable: node.exe
 log:
-    logpath: 'c:\\'
+    logPath: 'c:\\'
     mode: roll-by-size
     sizeThreshold: 112
     keepFiles: 113";
 
             var serviceDescriptor = YamlServiceConfig.FromYaml(yaml);
+
+            Assert.That(serviceDescriptor.Log.Directory, Is.EqualTo(@"c:\\"));
 
             serviceDescriptor.BaseName = "service";
 
@@ -289,12 +297,14 @@ name: Service
 description: The Service.
 executable: node.exe
 log:
-    logpath: c:\\
+    logPath: c:\\
     mode: roll-by-time
     period: 7
     pattern: log pattern";
 
             var serviceDescriptor = YamlServiceConfig.FromYaml(yaml);
+
+            Assert.That(serviceDescriptor.Log.Directory, Is.EqualTo(@"c:\\"));
 
             serviceDescriptor.BaseName = "service";
 
@@ -313,13 +323,15 @@ name: Service
 description: The Service.
 executable: node.exe
 log:
-    logpath: c:\\
+    logPath: c:\\
     mode: roll-by-size-time
     sizeThreshold: 10240
     pattern: yyyy-MM-dd
     autoRollAtTime: 00:00:00";
 
             var serviceDescriptor = YamlServiceConfig.FromYaml(yaml);
+
+            Assert.That(serviceDescriptor.Log.Directory, Is.EqualTo(@"c:\\"));
 
             serviceDescriptor.BaseName = "service";
 


### PR DESCRIPTION
Fixes winsw/winsw#1042.

- Update YAML docs and sample config to use `logPath` (camelCase), matching the `RawYamlLog.LogPath` binding.
- Update `ServiceDescriptorYamlTest` to use `logPath` and assert the parsed log directory so the docs/sample can't drift again.

Tested: `dotnet test src/WinSW.Tests/WinSW.Tests.csproj -c Release -f net7.0-windows --filter FullyQualifiedName~winswTests.ServiceDescriptorYamlTest`
