### PR TITLE
Fix misleading XML encoding declaration in the ConfigXmlBuilder test class

### DIFF
--- a/.github/workflows/changelog-management.yml
+++ b/.github/workflows/changelog-management.yml
@@ -6,6 +6,6 @@ jobs:
   update_draft_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6.2.0
+      - uses: release-drafter/release-drafter@v6.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/WinSW.Tests/Util/ConfigXmlBuilder.cs
+++ b/src/WinSW.Tests/Util/ConfigXmlBuilder.cs
@@ -59,8 +59,9 @@ namespace WinSW.Tests.Util
             var str = new StringBuilder();
             if (this.PrintXmlVersion)
             {
-                // TODO: The encoding is generally wrong
-                str.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
+                // XML is constructed as an in-memory .NET string,
+                // so specifying encoding here can be misleading.
+                str.Append("<?xml version=\"1.0\"?>\n");
             }
 
             if (this.XmlComment != null)

--- a/src/WinSW.Tests/Util/ConfigXmlBuilder.cs
+++ b/src/WinSW.Tests/Util/ConfigXmlBuilder.cs
@@ -21,6 +21,8 @@ namespace WinSW.Tests.Util
 
         public string XmlComment { get; set; }
 
+        public string XmlEncoding { get; set; }
+
         public List<string> ExtensionXmls { get; } = new List<string>();
 
         private readonly List<string> configEntries = new();
@@ -59,9 +61,14 @@ namespace WinSW.Tests.Util
             var str = new StringBuilder();
             if (this.PrintXmlVersion)
             {
-                // XML is constructed as an in-memory .NET string,
-                // so specifying encoding here can be misleading.
-                str.Append("<?xml version=\"1.0\"?>\n");
+                if (string.IsNullOrEmpty(this.XmlEncoding))
+                {
+                    str.Append("<?xml version=\"1.0\"?>\n");
+                }
+                else
+                {
+                    str.AppendFormat("<?xml version=\"1.0\" encoding=\"{0}\"?>\n", this.XmlEncoding);
+                }
             }
 
             if (this.XmlComment != null)


### PR DESCRIPTION
Fixes #1158

In "src/WinSW.Tests/Util/ConfigXmlBuilder.cs" the XML declaration was generated as:

"<?xml version="1.0" encoding="utf-8"?>"

Since the XML is constructed as an in-memory .NET string, specifying the encoding
can be misleading (the string is internally UTF-16).

This change removes the encoding attribute and keeps:

"<?xml version="1.0"?>"