### PR TITLE
Add keepFiles support for time-based log rolling

### DIFF
--- a/docs/logging-and-error-reporting.md
+++ b/docs/logging-and-error-reporting.md
@@ -48,10 +48,12 @@ Works like the append mode, but in addition, if the log file gets bigger than a 
 Works like the roll mode, except that instead of using the size as a threshold, use the time period as the threshold.
 
 This configuration must accompany a nested `<pattern>` element, which specifies the timestamp pattern used as the log file name.
+The optional `<keepFiles>` element specifies the number of rolled log files to keep. When the limit is exceeded, the oldest files are deleted automatically. If omitted, no files are deleted.
 
 ```xml
 <log mode="roll-by-time">
   <pattern>yyyyMMdd</pattern>
+  <keepFiles>30</keepFiles>
 </log>
 ```
 

--- a/src/WinSW.Core/Configuration/XmlServiceConfig.cs
+++ b/src/WinSW.Core/Configuration/XmlServiceConfig.cs
@@ -85,6 +85,7 @@ namespace WinSW
         /// Loads config from existing DOM
         /// </summary>
 #pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+
         public XmlServiceConfig(XmlDocument dom)
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
         {
@@ -301,7 +302,8 @@ namespace WinSW
 
                         string? pattern = patternNode.InnerText;
                         int period = SingleIntElement(e, "period", 1);
-                        return new TimeBasedRollingLogAppender(this.LogDirectory, this.LogName, this.OutFileDisabled, this.ErrFileDisabled, this.OutFilePattern, this.ErrFilePattern, pattern, period);
+                        int filesToKeep = SingleIntElement(e, "keepFiles", -1);
+                        return new TimeBasedRollingLogAppender(this.LogDirectory, this.LogName, this.OutFileDisabled, this.ErrFileDisabled, this.OutFilePattern, this.ErrFilePattern, pattern, period, filesToKeep);
 
                     case "roll-by-size":
                         sizeThreshold = SingleIntElement(e, "sizeThreshold", 10 * 1024) * SizeBasedRollingLogAppender.BytesPerKB;

--- a/src/WinSW.Core/LogAppenders.cs
+++ b/src/WinSW.Core/LogAppenders.cs
@@ -264,7 +264,7 @@ namespace WinSW
             writer.Dispose();
         }
 
-        private void PurgeOldFiles(string ext)
+        internal void PurgeOldFiles(string ext)
         {
             if (this.FilesToKeep <= 0)
             {

--- a/src/WinSW.Core/LogAppenders.cs
+++ b/src/WinSW.Core/LogAppenders.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Threading.Tasks;
 using WinSW.Util;
 
@@ -45,6 +46,7 @@ namespace WinSW
     public abstract class LogHandler
     {
 #pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+
         protected LogHandler(bool outFileDisabled, bool errFileDisabled)
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
         {
@@ -218,11 +220,14 @@ namespace WinSW
 
         public int Period { get; }
 
-        public TimeBasedRollingLogAppender(string logDirectory, string baseName, bool outFileDisabled, bool errFileDisabled, string outFilePattern, string errFilePattern, string pattern, int period)
+        public int FilesToKeep { get; }
+
+        public TimeBasedRollingLogAppender(string logDirectory, string baseName, bool outFileDisabled, bool errFileDisabled, string outFilePattern, string errFilePattern, string pattern, int period, int filesToKeep = -1)
             : base(logDirectory, baseName, outFileDisabled, errFileDisabled, outFilePattern, errFilePattern)
         {
             this.Pattern = pattern;
             this.Period = period;
+            this.FilesToKeep = filesToKeep;
         }
 
         protected override Task LogOutput(StreamReader outputReader)
@@ -250,12 +255,40 @@ namespace WinSW
                 if (periodicRollingCalendar.ShouldRoll)
                 {
                     writer.Dispose();
+                    this.PurgeOldFiles(ext);
                     copy.Writer = writer = new FileStream(this.BaseLogFileName + "_" + periodicRollingCalendar.Format + ext, FileMode.Create);
                 }
             }
 
             reader.Dispose();
             writer.Dispose();
+        }
+
+        private void PurgeOldFiles(string ext)
+        {
+            if (this.FilesToKeep <= 0)
+            {
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(this.BaseLogFileName)!;
+            var baseName = Path.GetFileName(this.BaseLogFileName);
+
+            var files = Directory.GetFiles(directory, baseName + "_*" + ext)
+                .OrderByDescending(File.GetLastWriteTime)
+                .Skip(this.FilesToKeep);
+
+            foreach (var file in files)
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch (IOException e)
+                {
+                    this.EventLogger.WriteEntry("Failed to purge old log file: " + e.Message);
+                }
+            }
         }
     }
 

--- a/src/WinSW.Tests/LogAppenderTests.cs
+++ b/src/WinSW.Tests/LogAppenderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Xunit;
@@ -113,7 +114,61 @@ namespace WinSW.Tests
             Assert.Equal(stderr.Skip(4), ReadAllBytes(Path.Combine(data.path, baseName + errFileExt)));
         }
 
-        private readonly ref struct TestData
+        [Fact]
+        public void TimeBasedRollingLogAppender_PurgeOldFiles_RemovesExcessFiles()
+        {
+            using var data = TestData.Create();
+
+            string outFileExt = ".out.log";
+            const int keepFiles = 3;
+
+            for (int i = 0; i < 5; i++)
+            {
+                string filePath = Path.Combine(data.path, $"{data.name}_{i:D8}{outFileExt}");
+                File.WriteAllText(filePath, "old log");
+                File.SetLastWriteTime(filePath, DateTime.Now.AddDays(-i));
+            }
+
+            var appender = new TimeBasedRollingLogAppender(
+                data.path, data.name,
+                false, false,
+                outFileExt, ".err.log",
+                "yyyyMMdd", 1,
+                filesToKeep: keepFiles);
+
+            appender.PurgeOldFiles(outFileExt);
+
+            var remaining = Directory.GetFiles(data.path, $"{data.name}_*{outFileExt}");
+            Assert.Equal(keepFiles, remaining.Length);
+        }
+
+        [Fact]
+        public void TimeBasedRollingLogAppender_PurgeOldFiles_NoLimitKeepsAllFiles()
+        {
+            using var data = TestData.Create();
+
+            string outFileExt = ".out.log";
+            const int totalFiles = 5;
+
+            for (int i = 0; i < totalFiles; i++)
+            {
+                File.WriteAllText(Path.Combine(data.path, $"{data.name}_{i:D8}{outFileExt}"), "log");
+            }
+
+            var appender = new TimeBasedRollingLogAppender(
+                data.path, data.name,
+                false, false,
+                outFileExt, ".err.log",
+                "yyyyMMdd", 1,
+                filesToKeep: -1);
+
+            appender.PurgeOldFiles(outFileExt);
+
+            var remaining = Directory.GetFiles(data.path, $"{data.name}_*{outFileExt}");
+            Assert.Equal(totalFiles, remaining.Length);
+        }
+
+        private readonly struct TestData : IDisposable
         {
             internal readonly string name;
             internal readonly string path;


### PR DESCRIPTION
Added <keepFiles> option to "roll-by-time" log mode, allowing configuration of how many rolled log files to retain. Updated documentation, XmlServiceConfig parsing, and TimeBasedRollingLogAppender to support and enforce file retention. Old log files are now purged automatically when the limit is exceeded.