### PR TITLE
Improve XML parsing error messages

### DIFF
--- a/src/WinSW.Core/Configuration/XmlServiceConfig.cs
+++ b/src/WinSW.Core/Configuration/XmlServiceConfig.cs
@@ -61,7 +61,7 @@ namespace WinSW
             }
             catch (XmlException e)
             {
-                throw new InvalidDataException(e.Message, e);
+                throw new InvalidDataException(EscapeNonPrintableCharacters(e.Message), e);
             }
 
             this.root = this.dom.SelectSingleNode(Names.Service) ?? throw new InvalidDataException("<" + Names.Service + "> is missing in configuration XML");
@@ -92,6 +92,14 @@ namespace WinSW
             this.dom = dom;
             this.root = this.dom.SelectSingleNode(Names.Service) ?? throw new InvalidDataException("<" + Names.Service + "> is missing in configuration XML");
             this.environmentVariables = this.LoadEnvironmentVariables();
+        }
+
+        private static string EscapeNonPrintableCharacters(string message)
+        {
+            return message
+                .Replace("\r", "\\r")
+                .Replace("\n", "\\n")
+                .Replace("\t", "\\t");
         }
 
         public static XmlServiceConfig FromXml(string xml)

--- a/src/WinSW.Tests/ServiceConfigTests.cs
+++ b/src/WinSW.Tests/ServiceConfigTests.cs
@@ -44,6 +44,27 @@ $@"<service>
         }
 
         [Fact]
+        public void InvalidXmlEscapesNonPrintableCharactersInErrorMessage()
+        {
+            string directory = FilesystemTestHelper.CreateTmpDirectory();
+            string path = Path.Combine(directory, "config.xml");
+
+            try
+            {
+                File.WriteAllText(path, "<\tservice></service>");
+
+                var exception = Assert.Throws<InvalidDataException>(() => new XmlServiceConfig(path));
+
+                Assert.Contains("\\t", exception.Message);
+                Assert.DoesNotContain("\t", exception.Message);
+            }
+            finally
+            {
+                Directory.Delete(directory, true);
+            }
+        }
+
+        [Fact]
         public void DefaultStartMode()
         {
             Assert.Equal(ServiceStartMode.Automatic, this.extendedServiceConfig.StartMode);


### PR DESCRIPTION
Fixes #462

## Summary

Improves XML parsing error messages by escaping invisible/non-printable characters in the message shown for invalid XML configuration files.

This makes characters such as tabs, carriage returns, and newlines visible as `\t`, `\r`, and `\n` instead of being printed directly in the error message.

## Scope

This PR focuses only on the XML parsing error-message part of the issue.

## Tests

- `dotnet test .\src\WinSW.Tests\WinSW.Tests.csproj -f net7.0-windows --filter "FullyQualifiedName~ServiceConfigTests"`